### PR TITLE
[Feat] 이용약관/개인정보처리방침 다이얼로그 구현 #89

### DIFF
--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/TermsFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/TermsFragment.kt
@@ -4,6 +4,9 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.project200.presentation.base.BindingFragment
+import com.project200.presentation.terms.TermsDialogFragment
+import com.project200.presentation.terms.TermsDialogFragment.Companion.PRIVACY
+import com.project200.presentation.terms.TermsDialogFragment.Companion.TERMS
 import com.project200.undabang.feature.auth.R
 import com.project200.undabang.feature.auth.databinding.FragmentTermsBinding
 import timber.log.Timber
@@ -24,10 +27,10 @@ class TermsFragment : BindingFragment<FragmentTermsBinding>(R.layout.fragment_te
         notifyBtnImv.setOnClickListener { viewModel.toggleNotify() }*/
 
         serviceTitleTv.setOnClickListener {
-            //TODO: 이용약관 다이얼로그
+            showTermsDialog(TERMS)
         }
         privacyTitleTv.setOnClickListener {
-            //TODO: 개인정보수집이용동의 다이얼로그
+            showTermsDialog(PRIVACY)
         }
 
         termsNextBtn.setOnClickListener {
@@ -58,5 +61,9 @@ class TermsFragment : BindingFragment<FragmentTermsBinding>(R.layout.fragment_te
             Timber.d("isAllRequiredChecked $allChecked")
             binding.termsNextBtn.isEnabled = allChecked
         }
+    }
+
+    private fun showTermsDialog(termsType: String) {
+        TermsDialogFragment(termsType).show(parentFragmentManager, TermsDialogFragment::class.java.simpleName)
     }
 }

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
@@ -11,6 +11,9 @@ import androidx.navigation.fragment.findNavController
 import com.project200.presentation.base.BindingFragment
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.presentation.base.BaseAlertDialog
+import com.project200.presentation.terms.TermsDialogFragment
+import com.project200.presentation.terms.TermsDialogFragment.Companion.PRIVACY
+import com.project200.presentation.terms.TermsDialogFragment.Companion.TERMS
 import com.project200.undabang.feature.profile.R
 import com.project200.undabang.feature.profile.databinding.FragmentSettingBinding
 import com.project200.undabang.oauth.AuthManager
@@ -52,8 +55,8 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
             }.show(parentFragmentManager, BaseAlertDialog::class.java.simpleName)
         }
         withdrawLl.setOnClickListener {  }
-        termsLl.setOnClickListener {  }
-        privacyLl.setOnClickListener {  }
+        termsLl.setOnClickListener { showTermsDialog(TERMS) }
+        privacyLl.setOnClickListener { showTermsDialog(PRIVACY) }
         versionInfoLl.setOnClickListener {  }
     }
 
@@ -76,6 +79,10 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
                 }
             })
         }
+    }
+
+    private fun showTermsDialog(termsType: String) {
+        TermsDialogFragment(termsType).show(parentFragmentManager, TermsDialogFragment::class.java.simpleName)
     }
 
     override fun onDestroy() {

--- a/presentation/src/main/java/com/project200/presentation/terms/TermsDialogFragment.kt
+++ b/presentation/src/main/java/com/project200/presentation/terms/TermsDialogFragment.kt
@@ -1,0 +1,84 @@
+package com.project200.presentation.terms
+
+import android.annotation.SuppressLint
+import android.graphics.Color
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.graphics.drawable.toDrawable
+import com.project200.presentation.base.BaseDialogFragment
+import com.project200.undabang.presentation.R
+import com.project200.undabang.presentation.databinding.DialogTermsBinding
+
+class TermsDialogFragment(
+    private val termsType: String
+): BaseDialogFragment<DialogTermsBinding>(R.layout.dialog_terms) {
+    override fun getViewBinding(view: View): DialogTermsBinding {
+        return DialogTermsBinding.bind(view)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.window?.let { window ->
+            val screenWidth = resources.displayMetrics.widthPixels
+            val desiredWidth = (screenWidth * 0.85).toInt()
+
+            window.setLayout(desiredWidth, WindowManager.LayoutParams.WRAP_CONTENT)
+
+            window.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun setupViews() {
+        binding.backBtn.setOnClickListener { dismiss() }
+
+        binding.webview.apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+
+            webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView?, url: String?, favicon: android.graphics.Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                }
+                override fun onPageFinished(view: WebView?, url: String?) { super.onPageFinished(view, url) }
+                override fun onReceivedError(
+                    view: WebView?,
+                    request: android.webkit.WebResourceRequest?,
+                    error: android.webkit.WebResourceError?
+                ) { super.onReceivedError(view, request, error) }
+            }
+
+
+            webChromeClient = WebChromeClient()
+            loadUrl(when(termsType) {
+                TERMS -> getString(R.string.terms_link)
+                PRIVACY -> getString(R.string.privacy_link)
+                else -> getString(R.string.terms_link)
+            })
+        }
+    }
+
+    override fun onDestroyView() {
+        binding.webview.let {
+            (it.parent as? ViewGroup)?.removeView(it)
+            it.stopLoading()
+            it.settings.javaScriptEnabled = false
+            it.clearHistory()
+            it.clearCache(true)
+            it.removeAllViews()
+            it.destroy()
+        }
+        super.onDestroyView()
+    }
+
+    companion object {
+        const val TERMS = "terms"
+        const val PRIVACY = "privacy"
+    }
+}

--- a/presentation/src/main/res/layout/dialog_terms.xml
+++ b/presentation/src/main/res/layout/dialog_terms.xml
@@ -1,0 +1,21 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:background="@drawable/dialog_radius"
+    tools:ignore="WebViewLayout">
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/back_btn"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_gravity="start"
+        android:background="@drawable/ic_arrow_back"/>
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_marginTop="16dp"
+        android:layout_height="300dp"/>
+</LinearLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -17,4 +17,8 @@
     <string name="update_desc">새로운 버전이 출시되었습니다.\n앱을 업데이트해주세요.</string>
     <string name="update_btn">업데이트</string>
     <string name="update_later_btn">나중에</string>
+
+    <!-- 이용약관, 개인정보처리방침 링크 -->
+    <string name="terms_link">https://fine-clarinet-5e2.notion.site/2005e05936ab8073b913e446d675dc84</string>
+    <string name="privacy_link">https://lydian-heliotrope-c1f.notion.site/20050c903a708026af52d95abd1adfb6</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#89 

## 📝작업 내용

- 이용약관, 개인정보처리방침 다이얼로그 구현
- 지금은 노션 게시해 놓은 링크로 웹뷰띄워놨는데 노션 상단바(복사, 공유, 워터마크 등등)를 못없애서 저희 프론트 서버에 띄우는걸로 변경 예정입니다. 추후에 링크만 바꾸면 될거 같아요!
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="395" alt="image" src="https://github.com/user-attachments/assets/bbd3e1e2-227f-4973-aff2-32b91d5f4157" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?