### PR TITLE
[Feat] 캘린더 오늘 날짜 이후로 텍스트 색상 회색으로 변경 #127

### DIFF
--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
@@ -72,10 +72,14 @@ class ExerciseMainFragment : BindingFragment<FragmentExerciseMainBinding>(R.layo
 
                     // 이번 달에 해당하는 날짜일 경우
                     if (data.position == DayPosition.MonthDate) {
-                        calendarDayTv.setTextColor(getColor(requireContext(), com.project200.undabang.presentation.R.color.black))
-
                         val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
                         todayIv.isVisible = data.date == today
+
+                        // 오늘 날짜 이후는 회색, 이전 및 당일은 검은색으로 처리
+                        calendarDayTv.setTextColor(getColor(requireContext(),
+                            if (data.date.isAfter(today)) com.project200.undabang.presentation.R.color.gray200
+                            else com.project200.undabang.presentation.R.color.black)
+                        )
 
                         // 운동 기록이 있는 날 && 애니메이션 중복 방지
                         if (exerciseCompleteDates.contains(data.date) && !exerciseCompleteIv.isVisible) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 캘린더 오늘 날짜 이후로 텍스트 색상 회색으로 변경

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?