### PR TITLE
[Feat] 앱 사용 중 토큰 만료 시 재발급 로직 구현 #135

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -37,7 +37,6 @@ class MainActivity : AppCompatActivity(), FragmentNavigator {
     private lateinit var navController: NavController
     private var isLoading = true // 스플래시 화면 유지를 위한 플래그
     private lateinit var binding: ActivityMainBinding
-    private lateinit var authService: AuthorizationService
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -45,7 +44,6 @@ class MainActivity : AppCompatActivity(), FragmentNavigator {
 
         // 스플래시 화면을 계속 보여줄 조건 설정
         splashScreen.setKeepOnScreenCondition { isLoading }
-        authService = AuthorizationService(this)
 
         setupObservers()
         performRouting()
@@ -57,7 +55,7 @@ class MainActivity : AppCompatActivity(), FragmentNavigator {
             if (currentAuthState.isAuthorized) {
                 if (currentAuthState.needsTokenRefresh) {
                     Timber.i("Token needs refresh. Attempting refresh...")
-                    when (val refreshResult = authManager.refreshAccessToken(authService)) {
+                    when (val refreshResult = authManager.refreshAccessToken()) {
                         is TokenRefreshResult.Success -> {
                             Timber.i("Token refresh successful.")
                             viewModel.checkIsRegistered() // 회원 여부 확인
@@ -158,12 +156,5 @@ class MainActivity : AppCompatActivity(), FragmentNavigator {
 
     override fun navigateFromExerciseMainToExerciseForm() {
         navController.navigate(ExerciseMainFragmentDirections.actionExerciseMainFragmentToExerciseFormFragment())
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (::authService.isInitialized) {
-            authService.dispose()
-        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">undabang</string>
+    <string name="error_token_refresh_failed">세션이 만료됐습니다. 로그인 화면으로 이동합니다.</string>
 </resources>

--- a/core/oauth/src/main/java/com/project200/undabang/oauth/AuthManager.kt
+++ b/core/oauth/src/main/java/com/project200/undabang/oauth/AuthManager.kt
@@ -42,6 +42,7 @@ sealed class TokenRefreshResult {
 
 @Singleton
 class AuthManager @Inject constructor(
+    private val authService: AuthorizationService,
     private val authStateManager: AuthStateManager,
     private val cognitoConfig: CognitoConfig
 ) {
@@ -67,7 +68,6 @@ class AuthManager @Inject constructor(
     }
 
     suspend fun initiateAuthorization(
-        authService: AuthorizationService,
         identityProvider: String? = null,
         callback: AuthResultCallback
     ) {
@@ -211,7 +211,7 @@ class AuthManager @Inject constructor(
         }
     }
 
-    suspend fun refreshAccessToken(authService: AuthorizationService): TokenRefreshResult {
+    suspend fun refreshAccessToken(): TokenRefreshResult {
         Timber.tag(TAG_DEBUG).d("Attempting to refresh access token.")
         val currentState = authStateManager.getCurrent()
         val refreshToken = currentState.refreshToken

--- a/core/oauth/src/main/java/com/project200/undabang/oauth/AuthManager.kt
+++ b/core/oauth/src/main/java/com/project200/undabang/oauth/AuthManager.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import androidx.core.net.toUri
 import com.project200.undabang.core.oauth.BuildConfig
 import com.project200.undabang.oauth.config.CognitoConfig
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
@@ -46,6 +48,8 @@ class AuthManager @Inject constructor(
     private val authStateManager: AuthStateManager,
     private val cognitoConfig: CognitoConfig
 ) {
+    private val _forceLogoutFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val forceLogoutFlow: SharedFlow<Unit> = _forceLogoutFlow
 
     private suspend fun fetchServiceConfiguration(): AuthorizationServiceConfiguration {
         return suspendCancellableCoroutine { continuation ->
@@ -245,6 +249,9 @@ class AuthManager @Inject constructor(
                         Timber.tag(TAG_DEBUG).w("Refresh token is invalid (invalid_grant). Clearing local AuthState.")
                         authStateManager.clearAuthState() // 리프레시 토큰이 무효하므로 로컬 상태 삭제
                     }
+
+                    // 토큰 갱신 실패 시 강제 로그아웃 트리거
+                    _forceLogoutFlow.tryEmit(Unit)
                     continuation.resume(TokenRefreshResult.Error(ex))
                 }
             }

--- a/core/oauth/src/main/java/com/project200/undabang/oauth/di/AuthCoreModule.kt
+++ b/core/oauth/src/main/java/com/project200/undabang/oauth/di/AuthCoreModule.kt
@@ -9,6 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import net.openid.appauth.AuthorizationService
 import javax.inject.Singleton
 
 @Module
@@ -26,11 +27,18 @@ object AuthCoreModule {
 
     @Provides
     @Singleton
+    fun provideAuthorizationService(@ApplicationContext context: Context): AuthorizationService {
+        return AuthorizationService(context)
+    }
+
+    @Provides
+    @Singleton
     fun provideAuthManager(
+        authService: AuthorizationService,
         authStateManager: AuthStateManager,
         cognitoConfig: CognitoConfig
     ): AuthManager {
-        return AuthManager(authStateManager, cognitoConfig)
+        return AuthManager(authService, authStateManager, cognitoConfig)
     }
 
     @Provides

--- a/data/src/main/java/com/project200/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/project200/data/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.project200.data.di
 import com.project200.data.api.ApiService
 import com.project200.data.utils.LocalDateAdapter
 import com.project200.data.utils.LocalDateTimeAdapter
+import com.project200.data.utils.TokenAuthenticator
 import com.project200.data.utils.TokenInterceptor
 import com.project200.undabang.data.BuildConfig
 import com.project200.undabang.oauth.AuthStateManager
@@ -55,10 +56,12 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(
+        tokenAuthenticator: TokenAuthenticator,
         loggingInterceptor: HttpLoggingInterceptor,
         tokenInterceptor: TokenInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .authenticator(tokenAuthenticator)
             .addInterceptor(loggingInterceptor)
             .addInterceptor(tokenInterceptor)
             .connectTimeout(30, TimeUnit.SECONDS)

--- a/data/src/main/java/com/project200/data/utils/TokenAuthenticator.kt
+++ b/data/src/main/java/com/project200/data/utils/TokenAuthenticator.kt
@@ -1,4 +1,66 @@
+// com.project200.data.utils.TokenAuthenticator.kt
+
 package com.project200.data.utils
 
-class TokenAuthenticator {
+import com.project200.undabang.oauth.AuthManager
+import com.project200.undabang.oauth.AuthStateManager
+import com.project200.undabang.oauth.TokenRefreshResult
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Provider // Provider를 사용하여 순환 참조 방지
+
+/**
+ * 이 클래스는 OkHttp의 Authenticator를 구현하여,
+ * 서버로부터 401 Unauthorized 응답을 받았을 때, 자동으로 액세스 토큰을 갱신하고
+ * 원래 요청을 재시도하는 역할을 합니다.
+ * */
+class TokenAuthenticator @Inject constructor(
+    private val authStateManager: AuthStateManager,
+    private val authManager: AuthManager, // 여기서는 직접 주입받아도 문제 없을 가능성이 높습니다.
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        // 이전에 사용된 토큰 (요청 실패한 토큰)
+        val originalAccessToken = response.request.header("Authorization")?.substringAfter("Bearer ")
+
+        // 동시에 여러 요청이 401을 받아 이 메소드로 진입하는 것을 방지하기 위한 동기화 블록
+        synchronized(this) {
+            val currentAccessToken = authStateManager.getCurrent().accessToken
+
+            // 토큰이 다른 스레드에 의해 갱신되었는지 확인
+            // 이전에 실패했던 토큰과 현재 저장된 토큰이 다르다면, 이미 토큰이 갱신 완료
+            if (originalAccessToken != null && originalAccessToken != currentAccessToken) {
+                Timber.tag("TokenAuthenticator").d("이미 토큰 재발급완료")
+                return response.request.newBuilder()
+                    .header("Authorization", "Bearer $currentAccessToken")
+                    .build()
+            }
+
+            // 토큰 갱신 시도
+            Timber.tag("TokenAuthenticator").w("Access token expired. Attempting to refresh.")
+            val refreshResult = runBlocking {
+                authManager.refreshAccessToken()
+            }
+
+            return when (refreshResult) {
+                is TokenRefreshResult.Success -> {
+                    // 토큰 갱신 성공: 새 토큰으로 새 요청 생성
+                    Timber.tag("TokenAuthenticator").i("토큰 갱신 성공, api 요청 재시도")
+                    response.request.newBuilder()
+                        .header("Authorization", "Bearer ${refreshResult.tokenResponse.accessToken}")
+                        .build()
+                }
+                else -> {
+                    // 토큰 갱신 실패
+                    Timber.tag("TokenAuthenticator").e("Token refresh failed. Cannot authenticate.")
+                    null
+                }
+            }
+        }
+    }
 }

--- a/data/src/main/java/com/project200/data/utils/TokenAuthenticator.kt
+++ b/data/src/main/java/com/project200/data/utils/TokenAuthenticator.kt
@@ -1,0 +1,4 @@
+package com.project200.data.utils
+
+class TokenAuthenticator {
+}

--- a/data/src/main/java/com/project200/data/utils/TokenInterceptor.kt
+++ b/data/src/main/java/com/project200/data/utils/TokenInterceptor.kt
@@ -13,6 +13,12 @@ class TokenInterceptor @Inject constructor(
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
+
+        // 이미 Authorization 헤더가 있다면, Authenticator가 설정한 것이므로 그대로 진행
+        if (originalRequest.header("Authorization") != null) {
+            return chain.proceed(originalRequest)
+        }
+
         val requestUrlString = originalRequest.url.toString()
         val currentAuthState = authStateManager.getCurrent()
 

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -110,12 +110,12 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
     override fun setupViews() {
         binding.googleLoginBtn.setOnClickListener {
             lifecycleScope.launch {
-                authManager.initiateAuthorization(authService, "Google", authCallback)
+                authManager.initiateAuthorization("Google", authCallback)
             }
         }
         binding.kakaoLoginBtn.setOnClickListener {
             lifecycleScope.launch {
-                authManager.initiateAuthorization(authService, "kakao", authCallback)
+                authManager.initiateAuthorization("kakao", authCallback)
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#135 

## 📝작업 내용

- 앱 사용 중 토큰 만료 시 재발급
  - 성공 시 해당 api 재요청
  - 실패 시 로그인 화면으로 이동, 토스트 메세지 띄우기

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?