### PR TITLE
[Feat] 운동 기록 시간 스피너 수정 #148

### DIFF
--- a/common/src/main/java/com/project200/common/utils/ClockProvider.kt
+++ b/common/src/main/java/com/project200/common/utils/ClockProvider.kt
@@ -1,9 +1,11 @@
 package com.project200.common.utils
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 interface ClockProvider {
     fun now(): LocalDate
+    fun localDateTimeNow(): LocalDateTime
     fun yearMonthNow(): YearMonth
 }

--- a/common/src/main/java/com/project200/common/utils/SystemClockProvider.kt
+++ b/common/src/main/java/com/project200/common/utils/SystemClockProvider.kt
@@ -1,10 +1,13 @@
 package com.project200.common.utils
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
+import java.time.ZoneId
 import javax.inject.Inject
 
 class SystemClockProvider @Inject constructor() : ClockProvider {
     override fun now(): LocalDate = LocalDate.now()
+    override fun localDateTimeNow(): LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
     override fun yearMonthNow(): YearMonth = YearMonth.now()
 }

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseFormFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseFormFragment.kt
@@ -166,7 +166,7 @@ class ExerciseFormFragment : BindingFragment<FragmentExerciseFormBinding>(R.layo
         }
 
         val initialCalendar = Calendar.getInstance().apply {
-            timeInMillis = dateTimeToShow.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            timeInMillis = dateTimeToShow.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()
         }
 
         // 다이얼로그 생성 및 표시

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseTimeDialogViewModel.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseTimeDialogViewModel.kt
@@ -1,0 +1,51 @@
+package com.project200.feature.exercise.form
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.project200.common.utils.ClockProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDateTime
+import java.time.ZoneId
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ExerciseTimeDialogViewModel @Inject constructor(
+    private val clockProvider: ClockProvider
+) : ViewModel() {
+
+    private val _initialDateTime = MutableLiveData<LocalDateTime?>()
+    val initialDateTime: LiveData<LocalDateTime?> = _initialDateTime
+
+
+    private val _event = MutableSharedFlow<Event>(replay = 0, extraBufferCapacity = 1)
+    val event: SharedFlow<Event> = _event
+
+    fun setInitialDateTime(dateTime: LocalDateTime?) {
+        _initialDateTime.value = dateTime
+    }
+
+    fun onDateTimeConfirmed(year: Int, month: Int, day: Int, hour: Int, minute: Int) {
+        val selectedDateTime = LocalDateTime.of(year, month, day, hour, minute)
+        val currentDateTime = clockProvider.localDateTimeNow()
+
+        val isTodaySelected = selectedDateTime.toLocalDate() == currentDateTime.toLocalDate()
+
+        viewModelScope.launch {
+            if (isTodaySelected && selectedDateTime.isAfter(currentDateTime)) {
+                _event.emit(Event.ShowFutureTimeErrorToast)
+                return@launch
+            }
+            _event.emit(Event.TimeSelected(year, month, day, hour, minute))
+        }
+    }
+
+    sealed class Event {
+        data class TimeSelected(val year: Int, val month: Int, val day: Int, val hour: Int, val minute: Int) : Event()
+        data object ShowFutureTimeErrorToast : Event()
+    }
+}

--- a/feature/exercise/src/main/res/values/strings.xml
+++ b/feature/exercise/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="exercise_record_max_image">사진은 최대 5개까지 등록할 수 있습니다.</string>
     <string name="exercise_record_image_access">사진 접근 권한이 필요합니다.</string>
     <string name="exercise_record_time_error">종료 시간은 시작 시간보다 빠를 수 없습니다.</string>
+    <string name="exercise_record_time_future_error">현재 시간까지만 선택할 수 있습니다.</string>
     <string name="exercise_record_delete">삭제하기</string>
     <string name="exercise_record_edit">수정하기</string>
     <string name="exercise_create_get_score">운동 기록하고 점수 얻기</string>

--- a/feature/exercise/src/test/java/com/project200/feature/exercise/ExerciseTimeDialogViewModelTest.kt
+++ b/feature/exercise/src/test/java/com/project200/feature/exercise/ExerciseTimeDialogViewModelTest.kt
@@ -1,0 +1,169 @@
+package com.project200.feature.exercise
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.project200.common.utils.ClockProvider
+import com.project200.feature.exercise.form.ExerciseTimeDialogViewModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDateTime
+
+@ExperimentalCoroutinesApi
+class ExerciseTimeDialogViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var mockClockProvider: ClockProvider
+
+    private lateinit var viewModel: ExerciseTimeDialogViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockClockProvider = mockk()
+        viewModel = ExerciseTimeDialogViewModel(mockClockProvider)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `onDateTimeConfirmed - 선택된 시간이 오늘 미래 시간일 경우, ShowFutureTimeErrorToast를 발행한다`() = runTest {
+        // Given: 현재 시간이 2025년 6월 27일 오전 10시 0분으로 가정
+        val currentMockDateTime = LocalDateTime.of(2025, 6, 27, 10, 0)
+        every { mockClockProvider.localDateTimeNow() } returns currentMockDateTime // ClockProvider의 localDateTimeNow() 사용
+
+        // When: 오늘 날짜의 미래 시간 (11시 0분)을 선택
+        val selectedYear = 2025
+        val selectedMonth = 6
+        val selectedDay = 27
+        val selectedHour = 11
+        val selectedMinute = 0
+
+        // Then: ShowFutureTimeErrorToast 이벤트가 발행되는지 확인
+        viewModel.event.test {
+            viewModel.onDateTimeConfirmed(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute)
+            val emittedEvent = awaitItem()
+            assertThat(emittedEvent).isEqualTo(ExerciseTimeDialogViewModel.Event.ShowFutureTimeErrorToast)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDateTimeConfirmed - 선택된 시간이 오늘 과거 시간일 경우, TimeSelected를 발행한다`() = runTest {
+        // Given: 현재 시간이 2025년 6월 27일 오전 10시 0분으로 가정
+        val currentMockDateTime = LocalDateTime.of(2025, 6, 27, 10, 0)
+        every { mockClockProvider.localDateTimeNow() } returns currentMockDateTime // ClockProvider의 localDateTimeNow() 사용
+
+        // When: 오늘 날짜의 과거 시간 (9시 0분)을 선택
+        val selectedYear = 2025
+        val selectedMonth = 6
+        val selectedDay = 27
+        val selectedHour = 9
+        val selectedMinute = 0
+
+        // Then: TimeSelected 이벤트가 발행되는지 확인
+        viewModel.event.test {
+            viewModel.onDateTimeConfirmed(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute)
+            val emittedEvent = awaitItem()
+            assertThat(emittedEvent).isEqualTo(
+                ExerciseTimeDialogViewModel.Event.TimeSelected(
+                    selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute
+                )
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDateTimeConfirmed - 선택된 시간이 오늘 현재 시간일 경우, TimeSelected를 발행한다`() = runTest {
+        // Given: 현재 시간이 2025년 6월 27일 오전 10시 0분으로 가정
+        val currentMockDateTime = LocalDateTime.of(2025, 6, 27, 10, 0)
+        every { mockClockProvider.localDateTimeNow() } returns currentMockDateTime // ClockProvider의 localDateTimeNow() 사용
+
+        // When: 오늘 날짜의 현재 시간 (10시 0분)을 선택
+        val selectedYear = 2025
+        val selectedMonth = 6
+        val selectedDay = 27
+        val selectedHour = 10
+        val selectedMinute = 0
+
+        // Then: TimeSelected 이벤트가 발행되는지 확인
+        viewModel.event.test {
+            viewModel.onDateTimeConfirmed(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute)
+            val emittedEvent = awaitItem()
+            assertThat(emittedEvent).isEqualTo(
+                ExerciseTimeDialogViewModel.Event.TimeSelected(
+                    selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute
+                )
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDateTimeConfirmed - 선택된 날짜가 과거일 경우, TimeSelected를 발행한다 (시간 무관)`() = runTest {
+        // Given: 현재 시간이 2025년 6월 27일 오전 10시 0분으로 가정
+        val currentMockDateTime = LocalDateTime.of(2025, 6, 27, 10, 0)
+        every { mockClockProvider.localDateTimeNow() } returns currentMockDateTime // ClockProvider의 localDateTimeNow() 사용
+
+        // When: 과거 날짜 (6월 26일)의 미래 시간 (11시 0분)을 선택
+        val selectedYear = 2025
+        val selectedMonth = 6
+        val selectedDay = 26
+        val selectedHour = 11
+        val selectedMinute = 0
+
+        // Then: TimeSelected 이벤트가 발행되는지 확인 (과거 날짜는 시간 제약 없음)
+        viewModel.event.test {
+            viewModel.onDateTimeConfirmed(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute)
+            val emittedEvent = awaitItem()
+            assertThat(emittedEvent).isEqualTo(
+                ExerciseTimeDialogViewModel.Event.TimeSelected(
+                    selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute
+                )
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setInitialDateTime은 initialDateTime LiveData를 업데이트한다`() {
+        // Given
+        val dateTime = LocalDateTime.of(2024, 1, 1, 12, 30)
+
+        // When
+        viewModel.setInitialDateTime(dateTime)
+
+        // Then
+        assertThat(viewModel.initialDateTime.value).isEqualTo(dateTime)
+    }
+
+    @Test
+    fun `setInitialDateTime에 null을 전달하면 initialDateTime LiveData가 null로 업데이트된다`() {
+        // Given
+        viewModel.setInitialDateTime(LocalDateTime.of(2024, 1, 1, 12, 30)) // 초기값 설정
+
+        // When
+        viewModel.setInitialDateTime(null)
+
+        // Then
+        assertThat(viewModel.initialDateTime.value).isNull()
+    }
+}

--- a/presentation/src/main/java/com/project200/presentation/base/BaseDialogFragment.kt
+++ b/presentation/src/main/java/com/project200/presentation/base/BaseDialogFragment.kt
@@ -19,11 +19,9 @@ abstract class BaseDialogFragment<VB : ViewBinding>(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = getViewBinding(view)
-        setupObservers()
         setupViews()
     }
 
-    open fun setupObservers() {}
     open fun setupViews() {}
 
     override fun onDestroyView() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#148 

## 📝작업 내용

- 운동 시간 스피너 수정
  - 현재 : 현재 시간을 넘어간 시간은 스피너에 표시되지 않음
  - 수정
    - 운동 시간 스피너를 23시간 55분까지로 고정
    - 미래 시점이라면 완료 버튼 클릭 시에 토스트 메세지 띄우기

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/0ebf1fcb-fcb0-4a5c-a45d-4bd7c508be64" width="300"/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?