### PR TITLE
[Feat] 운동 수정 후 상세 화면 백스택이 중복으로 들어가는 오류 수정 #148

### DIFF
--- a/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseFormFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/form/ExerciseFormFragment.kt
@@ -232,15 +232,15 @@ class ExerciseFormFragment : BindingFragment<FragmentExerciseFormBinding>(R.layo
         viewModel.editResult.observe(viewLifecycleOwner) { result ->
             when (result) {
                 is ExerciseEditResult.Success -> { // 기록 수정, 이미지 삭제/업로드 성공
-                    fragmentNavigator?.navigateFromExerciseFormToExerciseDetail(result.recordId)
+                    findNavController().popBackStack()
                 }
                 is ExerciseEditResult.ContentFailure -> { // 내용 수정 실패
                     Toast.makeText(requireContext(), result.message, Toast.LENGTH_SHORT).show()
-                    fragmentNavigator?.navigateFromExerciseFormToExerciseDetail(result.recordId)
+                    findNavController().popBackStack()
                 }
                 is ExerciseEditResult.ImageFailure -> { // 이미지 삭제/업로드 실패
                     Toast.makeText(requireContext(), result.message, Toast.LENGTH_SHORT).show()
-                    fragmentNavigator?.navigateFromExerciseFormToExerciseDetail(result.recordId)
+                    findNavController().popBackStack()
                 }
                 is ExerciseEditResult.Failure -> { // 내용 수정, 이미지 삭제/업로드 실패
                     Toast.makeText(requireContext(), result.message, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#148 

## 📝작업 내용
- 운동 수정 후 상세 화면 백스택이 중복으로 들어가는 오류 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?