### PR TITLE
[Fix] 운동 날짜 다이얼로그 QA #165

### DIFF
--- a/common/src/main/java/com/project200/common/utils/SystemClockProvider.kt
+++ b/common/src/main/java/com/project200/common/utils/SystemClockProvider.kt
@@ -7,7 +7,7 @@ import java.time.ZoneId
 import javax.inject.Inject
 
 class SystemClockProvider @Inject constructor() : ClockProvider {
-    override fun now(): LocalDate = LocalDate.now()
+    override fun now(): LocalDate = LocalDate.now(ZoneId.of("Asia/Seoul"))
     override fun localDateTimeNow(): LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-    override fun yearMonthNow(): YearMonth = YearMonth.now()
+    override fun yearMonthNow(): YearMonth = YearMonth.now(ZoneId.of("Asia/Seoul"))
 }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -6,6 +6,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.marginStart
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
+import com.project200.common.utils.ClockProvider
 import com.project200.domain.model.SignUpResult
 import com.project200.presentation.base.BindingFragment
 import com.project200.presentation.navigator.ActivityNavigator
@@ -25,6 +26,9 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
     @Inject
     lateinit var appNavigator: ActivityNavigator
 
+    @Inject
+    lateinit var clockProvider: ClockProvider
+
     override fun getViewBinding(view: View): FragmentRegisterBinding {
         return FragmentRegisterBinding.bind(view)
     }
@@ -37,7 +41,9 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
         }
 
         birthDayTv.setOnClickListener {
-            val datePicker = DatePickerDialogFragment(viewModel.birth.value) { selectedDate ->
+            val datePicker = DatePickerDialogFragment(
+                initialDateString = viewModel.birth.value,
+                maxDate = clockProvider.now().minusDays(1)) { selectedDate ->
                 viewModel.updateBirth(selectedDate)
             }
             datePicker.show(parentFragmentManager, DatePickerDialogFragment::class.java.simpleName)

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
@@ -14,7 +14,6 @@ import com.kizitonwose.calendar.view.ViewContainer
 import com.project200.common.constants.RuleConstants.SCORE_HIGH_LEVEL
 import com.project200.common.constants.RuleConstants.SCORE_MIDDLE_LEVEL
 import com.project200.common.utils.CommonDateTimeFormatters.YYYY_M_KR
-import com.project200.feature.exercise.list.ExerciseYearMonthDialog
 import com.project200.presentation.base.BindingFragment
 import com.project200.presentation.navigator.FragmentNavigator
 import com.project200.undabang.feature.exercise.R

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseYearMonthDialog.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseYearMonthDialog.kt
@@ -1,4 +1,4 @@
-package com.project200.feature.exercise.list
+package com.project200.feature.exercise.main
 
 import android.graphics.Color
 import android.os.Build

--- a/presentation/src/main/java/com/project200/presentation/base/DatePickerDialogFragment.kt
+++ b/presentation/src/main/java/com/project200/presentation/base/DatePickerDialogFragment.kt
@@ -16,6 +16,7 @@ import java.util.Locale
 
 class DatePickerDialogFragment(
     private val initialDateString: String? = null,
+    private val maxDate: LocalDate? = null,
     private val onDateSelected: (String) -> Unit
 ) : BaseDialogFragment<DialogDatePickerBinding>(R.layout.dialog_date_picker) {
 
@@ -24,9 +25,16 @@ class DatePickerDialogFragment(
     }
 
     override fun setupViews() = with(binding) {
-        val today = Calendar.getInstance()
-        today.add(Calendar.DAY_OF_YEAR, -1) // 어제 날짜를 최대 날짜로 설정 (오늘 날짜 선택 불가)
-        datePicker.maxDate = today.timeInMillis
+        val calendarMaxDate = Calendar.getInstance().apply {
+            maxDate?.let {
+                set(it.year, it.monthValue - 1, it.dayOfMonth)
+            } ?: run {
+                // maxDate가 null이면 오늘 날짜로 설정
+                timeInMillis = System.currentTimeMillis()
+            }
+        }
+        datePicker.maxDate = calendarMaxDate.timeInMillis
+
         datePicker.minDate = LocalDate.of(MIN_YEAR, 8, 15).toEpochDay() * 24 * 60 * 60 * 1000L // 최소 날짜 설정
 
         val defaultDate = LocalDate.of(2000, 1, 1) // 기본값 2000년 1월 1일


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 운동 기록 리스트와 회원가입에서 같은 DatePickerDialog 사용 중
  - maxDate를 인자로 넘겨받아서 날짜 다이얼로그 회원가입에서만 오늘 날짜 제한하도록 변경
  - maxDate의 기본값은 오늘 시간

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?