### PR TITLE
[Feat] 다른 소셜에 가입되어 있는 이메일로 로그인 시도 시 처리 #165

### DIFF
--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -44,11 +44,9 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
                 if (ex?.code == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW.code) {
                     // 사용자가 뒤로가기를 눌러서 직접 취소한 경우
                     Timber.tag(TAG).i("로그인 사용자 취소")
-                } else if (ex?.errorDescription?.contains("ACCOUNT_LINKED_SUCCESS") == true) {
-                    Toast.makeText(this, "기존의 계정과 성공적으로 통합되었습니다.\n다시 로그인해주세요.", Toast.LENGTH_LONG).show()
                 } else {
                     // 그 외 실제 오류 (네트워크, 서버, 인증 거부 등)
-                    Timber.tag(TAG).e(ex, "로그인에 실패했습니다.: ${ex?.errorDescription}")
+                    Timber.tag(TAG).e(ex, "authorizationLauncher 로그인에 실패했습니다.: ${ex?.errorDescription}")
                     Toast.makeText(this, "로그인에 실패했습니다.", Toast.LENGTH_SHORT).show()
                 }
             }
@@ -65,7 +63,18 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
         }
 
         override fun onError(exception: AuthorizationException?) {
-            Timber.tag(TAG).e(exception, "로그인 실패: ${exception?.errorDescription}")
+            Timber.tag(TAG).e(exception, "onError 로그인 실패: ${exception?.errorDescription}")
+            when {
+                // 이미 같은 이메일로 다른 소셜에 가입되어 있는 경우, 계정 통합 안내
+                exception?.errorDescription?.contains("ACCOUNT_LINKED_SUCCESS") == true -> {
+                    Timber.tag(TAG).e(exception, "onError 로그인 실패: ${exception?.errorDescription}")
+                    Toast.makeText(this@LoginActivity, "기존의 계정과 통합되었습니다.\n다시 로그인해주세요.", Toast.LENGTH_LONG).show()
+                }
+                else -> {
+                    // 그 외 일반적인 로그인 실패 오류 (네트워크, 서버 오류, 유효하지 않은 요청 등)
+                    Toast.makeText(this@LoginActivity, "로그인에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                }
+            }
         }
 
         override fun onConfigurationError(exception: Exception) {

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -44,6 +44,8 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
                 if (ex?.code == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW.code) {
                     // 사용자가 뒤로가기를 눌러서 직접 취소한 경우
                     Timber.tag(TAG).i("로그인 사용자 취소")
+                } else if (ex?.errorDescription?.contains("ACCOUNT_LINKED_SUCCESS") == true) {
+                    Toast.makeText(this, "기존의 계정과 성공적으로 통합되었습니다.\n다시 로그인해주세요.", Toast.LENGTH_LONG).show()
                 } else {
                     // 그 외 실제 오류 (네트워크, 서버, 인증 거부 등)
                     Timber.tag(TAG).e(ex, "로그인에 실패했습니다.: ${ex?.errorDescription}")


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 다른 소셜에 가입되어 있는 이메일로 로그인 시도 시 
  - 계정 통합 안내 토스트 메세지 구현
  - 통합 완료 후에는 재시도할 때 같은 계정으로 로그인/회원가입 진행

### 스크린샷 (선택)

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/e054c774-08ed-4c7d-addc-1144aca681ef" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?