### PR TITLE
[Feat] 운동 점수 조회에서 최소/최대 점수를 받아서 뷰 설정 #196

### DIFF
--- a/common/src/main/java/com/project200/common/constants/RuleConstants.kt
+++ b/common/src/main/java/com/project200/common/constants/RuleConstants.kt
@@ -7,6 +7,6 @@ object RuleConstants {
 
     const val MIN_YEAR = 1945
 
-    const val SCORE_HIGH_LEVEL = 70
-    const val SCORE_MIDDLE_LEVEL = 33
+    const val SCORE_HIGH_LEVEL = 0.70
+    const val SCORE_MIDDLE_LEVEL = 0.33
 }

--- a/data/src/main/java/com/project200/data/dto/MemberDTO.kt
+++ b/data/src/main/java/com/project200/data/dto/MemberDTO.kt
@@ -6,5 +6,7 @@ import java.time.LocalDateTime
 @JsonClass(generateAdapter = true)
 data class GetScoreDTO(
     val memberId: String,
-    val memberScore: Int
+    val memberScore: Int,
+    val policyMaxScore: Int,
+    val policyMinScore: Int
 )

--- a/data/src/main/java/com/project200/data/mapper/MebmerMapper.kt
+++ b/data/src/main/java/com/project200/data/mapper/MebmerMapper.kt
@@ -8,6 +8,8 @@ import com.project200.domain.model.Score
 
 fun GetScoreDTO.toModel(): Score {
     return Score(
-        score = memberScore
+        score = memberScore,
+        maxScore = policyMaxScore,
+        minScore = policyMinScore
     )
 }

--- a/domain/src/main/java/com/project200/domain/model/MemberModel.kt
+++ b/domain/src/main/java/com/project200/domain/model/MemberModel.kt
@@ -2,5 +2,7 @@ package com.project200.domain.model
 
 
 data class Score(
-    val score: Int
+    val score: Int,
+    val maxScore: Int = 0,
+    val minScore: Int = 100
 )

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
@@ -161,15 +161,21 @@ class ExerciseMainFragment : BindingFragment<FragmentExerciseMainBinding>(R.layo
 
         viewModel.score.observe(viewLifecycleOwner) { score ->
             binding.scoreProgressBar.apply {
+                maxScore = score.maxScore
+                minScore = score.minScore
                 this.score = score.score
             }
             binding.scoreTv.text = getString(R.string.exercise_score_format, score.score)
 
+            // 점수 레벨 아이콘 설정
+            val scoreRange = score.maxScore - score.minScore
+            val highLevelScore = (score.minScore + scoreRange * SCORE_HIGH_LEVEL).toInt()
+            val middleLevelScore = (score.minScore + scoreRange * SCORE_MIDDLE_LEVEL).toInt()
 
             binding.scoreLevelIv.setImageResource(
                  when {
-                     score >= SCORE_HIGH_LEVEL -> R.drawable.ic_score_high_level
-                     score >= SCORE_MIDDLE_LEVEL -> R.drawable.ic_score_middle_level
+                     score.score >= highLevelScore -> R.drawable.ic_score_high_level
+                     score.score >= middleLevelScore -> R.drawable.ic_score_middle_level
                      else -> R.drawable.ic_score_low_level
                  }
              )

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
@@ -20,6 +20,7 @@ import com.project200.undabang.feature.exercise.R
 import com.project200.undabang.feature.exercise.databinding.CalendarDayLayoutBinding
 import com.project200.undabang.feature.exercise.databinding.FragmentExerciseMainBinding
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -159,8 +160,11 @@ class ExerciseMainFragment : BindingFragment<FragmentExerciseMainBinding>(R.layo
         }
 
         viewModel.score.observe(viewLifecycleOwner) { score ->
-            binding.scoreProgressBar.score = score
-            binding.scoreTv.text = getString(R.string.exercise_score_format, score)
+            binding.scoreProgressBar.apply {
+                this.score = score.score
+            }
+            binding.scoreTv.text = getString(R.string.exercise_score_format, score.score)
+
 
             binding.scoreLevelIv.setImageResource(
                  when {

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainViewModel.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.project200.common.utils.ClockProvider
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.PolicyGroup
+import com.project200.domain.model.Score
 import com.project200.domain.usecase.GetExerciseCountInMonthUseCase
 import com.project200.domain.usecase.GetScorePolicyUseCase
 import com.project200.domain.usecase.GetScoreUseCase
@@ -36,8 +37,8 @@ class ExerciseMainViewModel @Inject constructor(
 
     private val exerciseCache = mutableMapOf<YearMonth, Set<LocalDate>>()
 
-    private val _score = MutableLiveData<Int>()
-    val score: LiveData<Int> = _score
+    private val _score = MutableLiveData<Score>()
+    val score: LiveData<Score> = _score
 
     private val _scorePolicy = MutableLiveData<PolicyGroup?>()
     val scorePolicy: LiveData<PolicyGroup?> = _scorePolicy
@@ -123,7 +124,7 @@ class ExerciseMainViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = getScoreUseCase()) {
                 is BaseResult.Success -> {
-                    _score.value = result.data.score
+                    _score.value = result.data
                 }
                 is BaseResult.Error -> {
                     _toastMessage.value = result.message

--- a/feature/exercise/src/test/java/com/project200/feature/exercise/ExerciseMainViewModelTest.kt
+++ b/feature/exercise/src/test/java/com/project200/feature/exercise/ExerciseMainViewModelTest.kt
@@ -253,7 +253,6 @@ class ExerciseMainViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        // --- 수정된 부분 ---
         // refreshData()가 한 번만 호출되었으므로 getScoreUseCase도 1번만 호출됩니다.
         coVerify(exactly = 1) { mockGetScoreUseCase.invoke() }
         assertThat(viewModel.score.value).isEqualTo(expectedScore)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#196

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 운동 점수 조회에서 최소/최대 점수를 받아서 뷰 설정
- 동적으로 점수 이미지, 프로그레스바 조정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?