### PR TITLE
[Feat] 커스텀 타이머 상세조회 api 연결 #254

### DIFF
--- a/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
@@ -56,7 +56,13 @@ class TimerRepositoryImpl @Inject constructor(
 
     // 커스텀 타이머 상세 조회
     override suspend fun getCustomTimer(customTimerId: Long): BaseResult<CustomTimer> {
-        TODO("Not yet implemented")
+        return apiCallBuilder(
+            ioDispatcher = ioDispatcher,
+            apiCall = { apiService.getCustomTimer(customTimerId) },
+            mapper = { dto: GetCustomTimerDetailDTO? ->
+                dto?.toModel() ?: CustomTimer(-1L, "")
+            }
+        )
     }
 
     // 커스텀 타이머 생성

--- a/domain/src/main/java/com/project200/domain/usecase/GetCustomTimerUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/GetCustomTimerUseCase.kt
@@ -1,0 +1,14 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.model.BaseResult
+import com.project200.domain.model.CustomTimer
+import com.project200.domain.repository.TimerRepository
+import javax.inject.Inject
+
+class GetCustomTimerUseCase @Inject constructor(
+    private val timerRepository: TimerRepository
+) {
+    suspend operator fun invoke(customTimerId: Long): BaseResult<CustomTimer> {
+        return timerRepository.getCustomTimer(customTimerId)
+    }
+}

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerViewModel.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerViewModel.kt
@@ -4,15 +4,22 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.project200.domain.model.Step
 import com.project200.domain.manager.TimerManager
+import com.project200.domain.model.BaseResult
+import com.project200.domain.model.CustomTimer
+import com.project200.domain.usecase.GetCustomTimerUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CustomTimerViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle,
-    private val timerManager: TimerManager
+    private val timerManager: TimerManager,
+    private val getCustomTimerUseCase: GetCustomTimerUseCase
 ): ViewModel() {
     // 전체 타이머 시간 (밀리초 단위)
     var totalTime: Long = 0L
@@ -22,8 +29,11 @@ class CustomTimerViewModel @Inject constructor(
     var totalStepTime: Long = 0L
         private set
 
-    private val customTimerId: Long = savedStateHandle.get<Long>("customTimerId")
-        ?: throw IllegalStateException("customTimerId is required for CustomTimerViewModel")
+    var customTimerId: Long? = null
+        private set
+
+    private val _title = MutableLiveData<String>()
+    val title: LiveData<String> = _title
 
     private val _currentStepIndex = MutableLiveData<Int>()
     val currentStepIndex: LiveData<Int> = _currentStepIndex
@@ -38,16 +48,7 @@ class CustomTimerViewModel @Inject constructor(
     val isRepeatEnabled: LiveData<Boolean> = _isRepeatEnabled
 
     // Step의 time은 '초' 단위
-    private val _steps = MutableLiveData<List<Step>>(listOf(
-        Step(1, 1, 3 ,"준비 운동"),
-        Step(2, 2, 5, "고강도 운동"),
-        Step(3, 3, 3, "휴식"),
-        Step(4, 4, 5, "마무리 운동"),
-        Step(5, 5, 2, "마무리 운동1"),
-        Step(6, 6, 2, "마무리 운동2"),
-        Step(7, 7, 3, "마무리 운동3"),
-        Step(8, 8, 4, "마무리 운동4"),
-    ))
+    private val _steps = MutableLiveData<List<Step>>()
     val steps: LiveData<List<Step>> = _steps
 
     private val _remainingTime = MutableLiveData<Long>()
@@ -56,9 +57,30 @@ class CustomTimerViewModel @Inject constructor(
     private val _isTimerRunning = MutableLiveData<Boolean>()
     val isTimerRunning: LiveData<Boolean>  = _isTimerRunning
 
+    private val _errorEvent = MutableSharedFlow<Boolean>()
+    val errorEvent: SharedFlow<Boolean> = _errorEvent
+
     init {
         setupTimerManager()
         resetTimer()
+    }
+
+    fun loadTimerData(id: Long) {
+        if (customTimerId == id) return
+        this.customTimerId = id
+        viewModelScope.launch {
+            when (val result = getCustomTimerUseCase(id)) {
+                is BaseResult.Success -> {
+                    val customTimer = result.data
+                    _title.value = customTimer.name
+                    _steps.value = customTimer.steps.sortedBy { it.order }
+                    resetTimer()
+                }
+                is BaseResult.Error -> {
+                    _errorEvent.emit(true)
+                }
+            }
+        }
     }
 
     // TimerManager의 콜백을 설정하는 초기화 함수

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/StepRVAdapter.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/StepRVAdapter.kt
@@ -11,10 +11,14 @@ import com.project200.undabang.feature.timer.databinding.ItemCustomTimerStepBind
 import com.project200.undabang.presentation.R
 
 class StepRVAdapter(
-    private val items: List<Step>,
 ) : RecyclerView.Adapter<StepRVAdapter.StepViewHolder>() {
-
+    private var items: List<Step> = emptyList()
     private var highlightedPosition = -1
+
+    fun submitList(newItems: List<Step>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
 
     fun highlightItem(position: Int) {
         val oldPosition = highlightedPosition

--- a/feature/timer/src/main/res/navigation/timer_nav_graph.xml
+++ b/feature/timer/src/main/res/navigation/timer_nav_graph.xml
@@ -36,7 +36,12 @@
         android:id="@+id/customTimerFragment"
         android:name="com.project200.feature.timer.custom.CustomTimerFragment"
         android:label="CustomTimerFragment"
-        tools:layout="@layout/fragment_custom_timer" />
+        tools:layout="@layout/fragment_custom_timer" >
+        <argument
+            android:name="customTimerId"
+            app:argType="long"
+            android:defaultValue="-1L" />
+    </fragment>
 
     <fragment
         android:id="@+id/customTimerFormFragment"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#254 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커스텀 타이머 상세조회 api 연결
- 기존 savedStateHandle로 timerId를 받아오는 것을 navigation의 argument로 변경했습니다.
- 에러 발생 시 toast 메세지를 출력하고 뒤로가기 처리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?