### PR TITLE
[Feat] 커스텀 타이머 생성 api 연결 #256

### DIFF
--- a/data/src/main/java/com/project200/data/api/ApiService.kt
+++ b/data/src/main/java/com/project200/data/api/ApiService.kt
@@ -1,6 +1,7 @@
 package com.project200.data.api
 
 import com.project200.data.dto.BaseResponse
+import com.project200.data.dto.CustomTimerIdDTO
 import com.project200.data.dto.GetCustomTimerDetailDTO
 import com.project200.data.dto.ExerciseIdDto
 import com.project200.data.dto.ExpectedScoreInfoDTO
@@ -164,7 +165,7 @@ interface ApiService {
     @AccessTokenApi
     suspend fun postCustomTimer(
         @Body customTimer: PostCustomTimerRequest
-    ): BaseResponse<Any?>
+    ): BaseResponse<CustomTimerIdDTO>
 
     // 커스텀 타이머 삭제
     @DELETE("api/v1/custom-timers/{customTimerId}")

--- a/data/src/main/java/com/project200/data/dto/TimerDTO.kt
+++ b/data/src/main/java/com/project200/data/dto/TimerDTO.kt
@@ -50,3 +50,7 @@ data class PostCustomTimerStepDTO(
     val customTimerStepOrder: Int,
     val customTimerStepTime: Int
 )
+
+data class CustomTimerIdDTO(
+    val customTimerId: Long
+)

--- a/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.project200.data.impl
 
 import com.project200.common.di.IoDispatcher
 import com.project200.data.api.ApiService
+import com.project200.data.dto.CustomTimerIdDTO
 import com.project200.data.dto.GetCustomTimerDetailDTO
 import com.project200.data.dto.GetCustomTimerListDTO
 import com.project200.data.mapper.toModel
@@ -12,6 +13,8 @@ import com.project200.domain.repository.TimerRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import com.project200.data.dto.GetSimpleTimersDTO
 import com.project200.data.dto.PatchSimpleTimerRequest
+import com.project200.data.dto.PostCustomTimerRequest
+import com.project200.data.mapper.toDTO
 import com.project200.domain.model.SimpleTimer
 import com.project200.domain.model.Step
 import javax.inject.Inject
@@ -69,8 +72,21 @@ class TimerRepositoryImpl @Inject constructor(
     override suspend fun createCustomTimer(
         title: String,
         steps: List<Step>
-    ): BaseResult<Unit> {
-        TODO("Not yet implemented")
+    ): BaseResult<Long> {
+        return apiCallBuilder(
+            ioDispatcher = ioDispatcher,
+            apiCall = {
+                apiService.postCustomTimer(
+                    PostCustomTimerRequest(
+                        customTimerName = title,
+                        customTimerSteps = steps.toDTO()
+                    )
+                )
+            },
+            mapper = { dto: CustomTimerIdDTO? ->
+                dto?.customTimerId ?: throw IllegalStateException()
+            }
+        )
     }
 
     // 커스텀 타이머 삭제

--- a/data/src/main/java/com/project200/data/mapper/TimerMapper.kt
+++ b/data/src/main/java/com/project200/data/mapper/TimerMapper.kt
@@ -2,9 +2,11 @@ package com.project200.data.mapper
 
 import com.project200.data.dto.GetCustomTimerDetailDTO
 import com.project200.data.dto.GetCustomTimerListDTO
+import com.project200.data.dto.PostCustomTimerStepDTO
 import com.project200.domain.model.CustomTimer
 import com.project200.data.dto.SimpleTimerDTO
 import com.project200.domain.model.SimpleTimer
+import com.project200.domain.model.Step
 
 fun SimpleTimerDTO.toModel(): SimpleTimer {
     return SimpleTimer(
@@ -27,7 +29,7 @@ fun GetCustomTimerDetailDTO.toModel(): CustomTimer {
         id = this.customTimerId,
         name = this.customTimerName,
         steps = this.customTimerSteps.map {
-            com.project200.domain.model.Step(
+            Step(
                 id = it.customTimerStepId,
                 order = it.customTimerStepOrder,
                 time = it.customTimerStepTime,
@@ -35,4 +37,14 @@ fun GetCustomTimerDetailDTO.toModel(): CustomTimer {
             )
         }
     )
+}
+
+fun List<Step>.toDTO(): List<PostCustomTimerStepDTO> {
+    return this.map {
+        PostCustomTimerStepDTO(
+            customTimerStepName = it.name,
+            customTimerStepOrder = it.order,
+            customTimerStepTime = it.time
+        )
+    }
 }

--- a/domain/src/main/java/com/project200/domain/repository/TimerRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/TimerRepository.kt
@@ -11,7 +11,7 @@ interface TimerRepository {
 
     suspend fun getCustomTimerList(): BaseResult<List<CustomTimer>> // 커스텀 타이머 전체 조회
     suspend fun getCustomTimer(customTimerId: Long): BaseResult<CustomTimer> // 특정 커스텀 타이머 조회
-    suspend fun createCustomTimer(title: String, steps: List<Step>): BaseResult<Unit> // 커스텀 타이머 생성
+    suspend fun createCustomTimer(title: String, steps: List<Step>): BaseResult<Long> // 커스텀 타이머 생성
     suspend fun deleteCustomTimer(customTimerId: Long): BaseResult<Unit> // 커스텀 타이머 삭제
     suspend fun editCustomTimerTitle(customTimerId: Long, title: String): BaseResult<Long> // 커스텀 타이머 수정
 }

--- a/domain/src/main/java/com/project200/domain/usecase/CreateCustomTimerUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/CreateCustomTimerUseCase.kt
@@ -1,0 +1,16 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.model.BaseResult
+import com.project200.domain.model.Step
+import com.project200.domain.repository.TimerRepository
+import javax.inject.Inject
+
+class CreateCustomTimerUseCase @Inject constructor(
+    private val timerRepository: TimerRepository
+) {
+    suspend operator fun invoke(
+        title: String, steps: List<Step>
+    ): BaseResult<Long> {
+        return timerRepository.createCustomTimer(title, steps)
+    }
+}

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
@@ -123,10 +123,10 @@ class CustomTimerFormFragment : BindingFragment<FragmentCustomTimerFormBinding>(
             Toast.makeText(requireContext(), messageResId, Toast.LENGTH_SHORT).show()
         }
 
-        viewModel.confirmResult.observe(viewLifecycleOwner) {
-            if (it != null) {
+        viewModel.confirmResult.observe(viewLifecycleOwner) { id ->
+            if (id != null) {
                 findNavController().navigate(
-                    CustomTimerFormFragmentDirections.actionCustomTimerFormFragmentToCustomTimerFragment(it)
+                    CustomTimerFormFragmentDirections.actionCustomTimerFormFragmentToCustomTimerFragment(id)
                 )
             }
         }

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
@@ -114,6 +114,7 @@ class CustomTimerFormFragment : BindingFragment<FragmentCustomTimerFormBinding>(
                 ToastMessageType.EMPTY_TITLE -> R.string.custom_timer_error_empty_title
                 ToastMessageType.NO_STEPS -> R.string.custom_timer_error_no_steps
                 ToastMessageType.INVALID_STEP_TIME -> R.string.custom_timer_error_invalid_time
+                ToastMessageType.MAX_STEPS -> R.string.custom_timer_error_max_steps
                 // API 에러 메시지 매핑
                 ToastMessageType.CREATE_ERROR -> R.string.custom_timer_error_create_failed
                 ToastMessageType.EDIT_ERROR -> R.string.custom_timer_error_edit_failed

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
@@ -110,10 +110,15 @@ class CustomTimerFormFragment : BindingFragment<FragmentCustomTimerFormBinding>(
 
         viewModel.toast.observe(viewLifecycleOwner) { toast ->
             val messageResId = when (toast) {
-                is CustomTimerValidationResult.EmptyTitle -> R.string.custom_timer_error_empty_title
-                is CustomTimerValidationResult.NoSteps -> R.string.custom_timer_error_no_steps
-                is CustomTimerValidationResult.InvalidStepTime -> R.string.custom_timer_error_invalid_time
-                is CustomTimerValidationResult.Success -> return@observe
+                // 검증 결과에 따른 메시지 매핑
+                ToastMessageType.EMPTY_TITLE -> R.string.custom_timer_error_empty_title
+                ToastMessageType.NO_STEPS -> R.string.custom_timer_error_no_steps
+                ToastMessageType.INVALID_STEP_TIME -> R.string.custom_timer_error_invalid_time
+                // API 에러 메시지 매핑
+                ToastMessageType.CREATE_ERROR -> R.string.custom_timer_error_create_failed
+                ToastMessageType.EDIT_ERROR -> R.string.custom_timer_error_edit_failed
+                ToastMessageType.GET_ERROR -> R.string.error_failed_to_load_list
+                ToastMessageType.UNKNOWN_ERROR -> R.string.unknown_error
             }
             Toast.makeText(requireContext(), messageResId, Toast.LENGTH_SHORT).show()
         }

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
@@ -125,7 +125,7 @@ class CustomTimerFormFragment : BindingFragment<FragmentCustomTimerFormBinding>(
         }
 
         viewModel.confirmResult.observe(viewLifecycleOwner) { id ->
-            if (id != null) {
+            if (id != null &&  findNavController().currentDestination?.id == R.id.customTimerFormFragment) {
                 findNavController().navigate(
                     CustomTimerFormFragmentDirections.actionCustomTimerFormFragmentToCustomTimerFragment(id)
                 )

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
@@ -21,3 +21,13 @@ data class CustomTimerFormUiState(
     val title: String = "",
     val listItems: List<TimerFormListItem> = emptyList()
 )
+
+enum class ToastMessageType {
+    EMPTY_TITLE, // 제목이 비어있음
+    NO_STEPS, // 스텝이 하나도 없음
+    INVALID_STEP_TIME, // 스텝 시간이 0 이하임
+    GET_ERROR, // 조회 에러
+    CREATE_ERROR, // 생성 에러
+    EDIT_ERROR, // 수정 에러
+    UNKNOWN_ERROR
+}

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
@@ -26,6 +26,7 @@ enum class ToastMessageType {
     EMPTY_TITLE, // 제목이 비어있음
     NO_STEPS, // 스텝이 하나도 없음
     INVALID_STEP_TIME, // 스텝 시간이 0 이하임
+    MAX_STEPS, // 스텝 최대 개수 초과
     GET_ERROR, // 조회 에러
     CREATE_ERROR, // 생성 에러
     EDIT_ERROR, // 수정 에러

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormViewModel.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormViewModel.kt
@@ -86,6 +86,10 @@ class CustomTimerFormViewModel @Inject constructor(
 
     fun addStep() {
         val currentState = _uiState.value ?: return
+        if(currentState.listItems.size >= MAX_STEP_SIZE) {
+            _toast.value = ToastMessageType.MAX_STEPS
+            return
+        }
         val footer = currentState.listItems.last() as? TimerFormListItem.FooterItem ?: return
 
         val newStep = Step(
@@ -187,5 +191,6 @@ class CustomTimerFormViewModel @Inject constructor(
     companion object {
         const val DEFAULT_TIME = 60 // 기본 시간 60초
         const val DEFAULT_DUMMY_ID = -1L // 임시 ID
+        const val MAX_STEP_SIZE = 51 // 최대 스텝 개수 (50 + Footer)
     }
 }

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormViewModel.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormViewModel.kt
@@ -4,25 +4,30 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.project200.domain.model.BaseResult
 import com.project200.domain.model.Step
 import com.project200.domain.model.CustomTimerValidationResult
+import com.project200.domain.usecase.CreateCustomTimerUseCase
+import com.project200.domain.usecase.GetCustomTimerUseCase
 import com.project200.domain.usecase.ValidateCustomTimerUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.Collections
 import javax.inject.Inject
 
 
 @HiltViewModel
 class CustomTimerFormViewModel @Inject constructor(
-    private val validateCustomTimerUseCase: ValidateCustomTimerUseCase
+    private val validateCustomTimerUseCase: ValidateCustomTimerUseCase,
+    private val createCustomTimerUseCase: CreateCustomTimerUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableLiveData<CustomTimerFormUiState>()
     val uiState: LiveData<CustomTimerFormUiState> = _uiState
 
-    private val _toast = MutableLiveData<CustomTimerValidationResult>()
-    val toast: LiveData<CustomTimerValidationResult> = _toast
+    private val _toast = MutableLiveData<ToastMessageType>()
+    val toast: LiveData<ToastMessageType> = _toast
 
     private val _confirmResult = MutableLiveData<Long>()
     val confirmResult: LiveData<Long> = _confirmResult
@@ -144,7 +149,7 @@ class CustomTimerFormViewModel @Inject constructor(
     fun getStepsWithFinalOrder(): List<Step> {
         val currentSteps = _uiState.value?.listItems?.mapNotNull { it as? TimerFormListItem.StepItem } ?: emptyList()
         return currentSteps.mapIndexed { index, stepItem ->
-            stepItem.step.copy(order = index + 1)
+            stepItem.step.copy(order = index)
         }
     }
 
@@ -154,11 +159,28 @@ class CustomTimerFormViewModel @Inject constructor(
         val validationResult = validateCustomTimerUseCase(currentState.title, currentSteps)
 
         if (validationResult is CustomTimerValidationResult.Success) {
-            val finalSteps = getStepsWithFinalOrder()
-            // TODO: 서버에 전송
-            _confirmResult.value = 1L // 임시로 1L 반환, 실제로는 서버 응답 ID 사용
+            Timber.d("Validation passed, creating timer")
+            createCustomTimer(currentState.title, getStepsWithFinalOrder())
         } else {
-            _toast.value = validationResult
+            _toast.value = when (validationResult) {
+                is CustomTimerValidationResult.EmptyTitle -> ToastMessageType.EMPTY_TITLE
+                is CustomTimerValidationResult.NoSteps -> ToastMessageType.NO_STEPS
+                is CustomTimerValidationResult.InvalidStepTime -> ToastMessageType.INVALID_STEP_TIME
+                else -> null
+            }
+        }
+    }
+
+    private fun createCustomTimer(title: String, steps: List<Step>) {
+        viewModelScope.launch {
+            when (val result = createCustomTimerUseCase(title, steps)) {
+                is BaseResult.Success -> {
+                    _confirmResult.value = result.data
+                }
+                is BaseResult.Error -> {
+                    _toast.value = ToastMessageType.CREATE_ERROR
+                }
+            }
         }
     }
 

--- a/feature/timer/src/main/res/layout/fragment_custom_timer_form.xml
+++ b/feature/timer/src/main/res/layout/fragment_custom_timer_form.xml
@@ -35,6 +35,7 @@
         android:hint="@string/custom_timer_title_hint"
         android:inputType="text"
         android:maxLines="1"
+        android:maxLength="100"
         android:textColorHint="@color/gray200"
         android:textSize="24sp"
         app:layout_constraintTop_toBottomOf="@id/base_toolbar" />

--- a/feature/timer/src/main/res/layout/item_custom_timer_create_step.xml
+++ b/feature/timer/src/main/res/layout/item_custom_timer_create_step.xml
@@ -39,6 +39,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:maxLines="1"
+            android:maxLength="50"
             android:hint="@string/custom_timer_step_hint"
             android:textColorHint="@color/gray200"
             style="@style/content_bold"

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="custom_timer_error_empty_title">타이머 제목을 입력해주세요.</string>
     <string name="custom_timer_error_no_steps">스텝을 1개 이상 추가해주세요.</string>
     <string name="custom_timer_error_invalid_time">모든 스텝의 시간을 1초 이상으로 설정해주세요.</string>
+    <string name="custom_timer_error_max_steps">스텝은 50개까지 추가할 수 있어요.</string>
 
     <string name="error_failed_to_load_list">타이머를 불러오는데 실패했습니다.</string>
     <string name="custom_timer_error_create_failed">타이머를 생성하는데 실패했습니다.</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -18,7 +18,10 @@
     <string name="custom_timer_error_no_steps">스텝을 1개 이상 추가해주세요.</string>
     <string name="custom_timer_error_invalid_time">모든 스텝의 시간을 1초 이상으로 설정해주세요.</string>
 
-    <string name="error_failed_to_load_list">커스텀 타이머를 불러오는데 실패했습니다.</string>
+    <string name="error_failed_to_load_list">타이머를 불러오는데 실패했습니다.</string>
+    <string name="custom_timer_error_create_failed">타이머를 생성하는데 실패했습니다.</string>
+    <string name="custom_timer_error_edit_failed">타이머를 수정하는데 실패했습니다.</string>
+    <string name="unknown_error">알 수 없는 오류가 발생했습니다.</string>
 
     <string name="edit_simple_timer_error">타이머 수정에 실패했습니다.</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#256 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커스텀 타이머 생성 api 연결
- 커스텀 타이머 생성 성공 시 조회/실행 화면으로 이동합니다.
- 에러 발생 시, ToastMessageType으로 유효성 검증 실패와 api 에러를 toast LiveData에 전달하여 토스트 메세지를 띄우도록 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?