### PR TITLE
[Feat] 커스텀 타이머 수정 api 연결 #259

### DIFF
--- a/data/src/main/java/com/project200/data/api/ApiService.kt
+++ b/data/src/main/java/com/project200/data/api/ApiService.kt
@@ -180,12 +180,12 @@ interface ApiService {
     suspend fun patchCustomTimerTitle(
         @Path("customTimerId") customTimerId: Long,
         @Body title: PatchCustomTimerTitleRequest
-    ): BaseResponse<Long>
+    ): BaseResponse<CustomTimerIdDTO>
 
     // 커스텀 타이머 전체 수정
     @PUT("api/v1/custom-timers/{customTimerId}")
     suspend fun putCustomTimer(
         @Path("customTimerId") customTimerId: Long,
         @Body customTimer: PostCustomTimerRequest
-    ): BaseResponse<Any?>
+    ): BaseResponse<CustomTimerIdDTO>
 }

--- a/data/src/main/java/com/project200/data/api/ApiService.kt
+++ b/data/src/main/java/com/project200/data/api/ApiService.kt
@@ -18,6 +18,7 @@ import com.project200.data.dto.PostSignUpData
 import com.project200.data.dto.PostSignUpRequest
 import com.project200.data.dto.GetCustomTimerListDTO
 import com.project200.data.dto.GetSimpleTimersDTO
+import com.project200.data.dto.PatchCustomTimerTitleRequest
 import com.project200.data.dto.PatchSimpleTimerRequest
 import com.project200.data.dto.PostCustomTimerRequest
 import com.project200.data.utils.AccessTokenApi
@@ -30,6 +31,7 @@ import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -173,9 +175,17 @@ interface ApiService {
         @Path("customTimerId") customTimerId: Long
     ): BaseResponse<Any?>
 
+    // 커스텀 타이머 이름 수정
     @PATCH("api/v1/custom-timers/{customTimerId}")
-    suspend fun editCustomTimerTitle(
+    suspend fun patchCustomTimerTitle(
         @Path("customTimerId") customTimerId: Long,
-        @Body title: String
+        @Body title: PatchCustomTimerTitleRequest
     ): BaseResponse<Long>
+
+    // 커스텀 타이머 전체 수정
+    @PUT("api/v1/custom-timers/{customTimerId}")
+    suspend fun putCustomTimer(
+        @Path("customTimerId") customTimerId: Long,
+        @Body customTimer: PostCustomTimerRequest
+    ): BaseResponse<Any?>
 }

--- a/data/src/main/java/com/project200/data/dto/TimerDTO.kt
+++ b/data/src/main/java/com/project200/data/dto/TimerDTO.kt
@@ -54,3 +54,7 @@ data class PostCustomTimerStepDTO(
 data class CustomTimerIdDTO(
     val customTimerId: Long
 )
+
+data class PatchCustomTimerTitleRequest(
+    val customTimerName: String
+)

--- a/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/TimerRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.project200.domain.model.CustomTimer
 import com.project200.domain.repository.TimerRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import com.project200.data.dto.GetSimpleTimersDTO
+import com.project200.data.dto.PatchCustomTimerTitleRequest
 import com.project200.data.dto.PatchSimpleTimerRequest
 import com.project200.data.dto.PostCustomTimerRequest
 import com.project200.data.mapper.toDTO
@@ -102,7 +103,32 @@ class TimerRepositoryImpl @Inject constructor(
     override suspend fun editCustomTimerTitle(
         customTimerId: Long,
         title: String
-    ): BaseResult<Long> {
-        TODO("Not yet implemented")
+    ): BaseResult<Unit> {
+        return apiCallBuilder(
+            ioDispatcher = ioDispatcher,
+            apiCall = { apiService.patchCustomTimerTitle(customTimerId, PatchCustomTimerTitleRequest(title)) },
+            mapper = { Unit }
+        )
+    }
+
+    // 커스텀 타이머 전체 수정
+    override suspend fun editCustomTimer(
+        customTimerId: Long,
+        title: String,
+        steps: List<Step>
+    ): BaseResult<Unit> {
+        return apiCallBuilder(
+            ioDispatcher = ioDispatcher,
+            apiCall = {
+                apiService.putCustomTimer(
+                    customTimerId,
+                    PostCustomTimerRequest(
+                        customTimerName = title,
+                        customTimerSteps = steps.toDTO()
+                    )
+                )
+            },
+            mapper = { Unit }
+        )
     }
 }

--- a/domain/src/main/java/com/project200/domain/repository/TimerRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/TimerRepository.kt
@@ -13,5 +13,6 @@ interface TimerRepository {
     suspend fun getCustomTimer(customTimerId: Long): BaseResult<CustomTimer> // 특정 커스텀 타이머 조회
     suspend fun createCustomTimer(title: String, steps: List<Step>): BaseResult<Long> // 커스텀 타이머 생성
     suspend fun deleteCustomTimer(customTimerId: Long): BaseResult<Unit> // 커스텀 타이머 삭제
-    suspend fun editCustomTimerTitle(customTimerId: Long, title: String): BaseResult<Long> // 커스텀 타이머 수정
+    suspend fun editCustomTimerTitle(customTimerId: Long, title: String): BaseResult<Unit> // 커스텀 타이머 이름 수정
+    suspend fun editCustomTimer(customTimerId: Long, title: String, steps: List<Step>): BaseResult<Unit> // 커스텀 타이머 전체 수정
 }

--- a/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerNameUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerNameUseCase.kt
@@ -1,0 +1,13 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.model.BaseResult
+import com.project200.domain.repository.TimerRepository
+import javax.inject.Inject
+
+class EditCustomTimerNameUseCase @Inject constructor(
+    private val timerRepository: TimerRepository
+) {
+    suspend operator fun invoke(customTimerId: Long, title: String): BaseResult<Unit> {
+        return timerRepository.editCustomTimerTitle(customTimerId, title)
+    }
+}

--- a/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerUseCase.kt
@@ -1,13 +1,25 @@
 package com.project200.domain.usecase
 
+import com.project200.domain.model.BaseResult
 import com.project200.domain.model.Step
 import com.project200.domain.repository.TimerRepository
 import javax.inject.Inject
 
 class EditCustomTimerUseCase @Inject constructor(
-    private val timerRepository: TimerRepository
+    private val timerRepository: TimerRepository,
+    private val editCustomTimerNameUseCase: EditCustomTimerNameUseCase
 ) {
-    suspend operator fun invoke(customTimerId: Long, title: String, steps: List<Step>) {
-        timerRepository.editCustomTimer(customTimerId, title, steps)
+    suspend operator fun invoke(
+        hasTitleChanged: Boolean,
+        hasStepsChanged: Boolean,
+        customTimerId: Long,
+        title: String,
+        steps: List<Step>
+    ): BaseResult<Unit> {
+        return when {
+            hasStepsChanged -> timerRepository.editCustomTimer(customTimerId, title, steps)
+            hasTitleChanged -> editCustomTimerNameUseCase(customTimerId, title)
+            else -> BaseResult.Error(message = null)
+        }
     }
 }

--- a/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/EditCustomTimerUseCase.kt
@@ -1,0 +1,13 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.model.Step
+import com.project200.domain.repository.TimerRepository
+import javax.inject.Inject
+
+class EditCustomTimerUseCase @Inject constructor(
+    private val timerRepository: TimerRepository
+) {
+    suspend operator fun invoke(customTimerId: Long, title: String, steps: List<Step>) {
+        timerRepository.editCustomTimer(customTimerId, title, steps)
+    }
+}

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormFragment.kt
@@ -25,26 +25,24 @@ class CustomTimerFormFragment : BindingFragment<FragmentCustomTimerFormBinding>(
     private val viewModel: CustomTimerFormViewModel by viewModels()
     private lateinit var stepAdapter: AddedStepRVAdapter
     private lateinit var itemTouchHelper: ItemTouchHelper
-
     private val args: CustomTimerFormFragmentArgs by navArgs()
 
     override fun getViewBinding(view: View): FragmentCustomTimerFormBinding {
         return FragmentCustomTimerFormBinding.bind(view)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         viewModel.loadData(args.customTimerId)
     }
 
     override fun setupViews() {
         binding.baseToolbar.apply {
-            val titleRes = if (viewModel.isEditMode) R.string.custom_timer_edit else R.string.custom_timer_create
+            setTitle(getString(if (viewModel.isEditMode) R.string.custom_timer_edit else R.string.custom_timer_create))
             showBackButton(true) { findNavController().navigateUp() }
         }
         initRecyclerView()
         initListeners()
-        setupObservers()
     }
 
     private fun initListeners() {

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFormUiState.kt
@@ -30,5 +30,6 @@ enum class ToastMessageType {
     GET_ERROR, // 조회 에러
     CREATE_ERROR, // 생성 에러
     EDIT_ERROR, // 수정 에러
+    NO_CHANGES, // 수정 에러
     UNKNOWN_ERROR
 }

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFragment.kt
@@ -41,7 +41,12 @@ class CustomTimerFragment: BindingFragment<FragmentCustomTimerBinding>(R.layout.
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.loadTimerData(args.customTimerId)
+        viewModel.setTimerId(args.customTimerId)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.loadTimerData()
     }
 
     override fun setupViews() {

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerFragment.kt
@@ -241,10 +241,13 @@ class CustomTimerFragment: BindingFragment<FragmentCustomTimerBinding>(R.layout.
     private fun showMenu() {
         MenuBottomSheetDialog(
             onEditClicked = {
-                // TODO: 타이머 수정 기능이 추가되면 구현 예정
+                findNavController().navigate(
+                    CustomTimerFragmentDirections.actionCustomTimerToCustomTimerFormFragment(
+                        viewModel.customTimerId
+                    )
+                )
             },
             onDeleteClicked = { showDeleteConfirmationDialog() },
-            isEditVisible = false // TODO: 타이머 수정 기능이 추가되면 제거 예정
         ).show(parentFragmentManager, MenuBottomSheetDialog::class.java.simpleName)
     }
 

--- a/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerViewModel.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/custom/CustomTimerViewModel.kt
@@ -31,7 +31,7 @@ class CustomTimerViewModel @Inject constructor(
     var totalStepTime: Long = 0L
         private set
 
-    var customTimerId: Long = -1L
+    var customTimerId: Long = DUMMY_TIMER_ID
         private set
 
     private val _title = MutableLiveData<String>()
@@ -70,11 +70,14 @@ class CustomTimerViewModel @Inject constructor(
         resetTimer()
     }
 
-    fun loadTimerData(id: Long) {
-        if (customTimerId == id) return
+    fun setTimerId(id: Long) {
+        if(id == DUMMY_TIMER_ID) return
         this.customTimerId = id
+    }
+
+    fun loadTimerData() {
         viewModelScope.launch {
-            when (val result = getCustomTimerUseCase(id)) {
+            when (val result = getCustomTimerUseCase(customTimerId)) {
                 is BaseResult.Success -> {
                     val customTimer = result.data
                     _title.value = customTimer.name
@@ -187,5 +190,9 @@ class CustomTimerViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         timerManager.cancel()
+    }
+
+    companion object {
+        private const val DUMMY_TIMER_ID = -1L
     }
 }

--- a/feature/timer/src/main/res/navigation/timer_nav_graph.xml
+++ b/feature/timer/src/main/res/navigation/timer_nav_graph.xml
@@ -41,6 +41,13 @@
             android:name="customTimerId"
             app:argType="long"
             android:defaultValue="-1L" />
+        <action
+            android:id="@+id/action_customTimer_to_customTimerFormFragment"
+            app:destination="@id/customTimerFormFragment">
+            <argument
+                android:name="customTimerId"
+                app:argType="long" />
+        </action>
     </fragment>
 
     <fragment

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -17,8 +17,9 @@
 
     <string name="custom_timer_error_empty_title">타이머 제목을 입력해주세요.</string>
     <string name="custom_timer_error_no_steps">스텝을 1개 이상 추가해주세요.</string>
-    <string name="custom_timer_error_invalid_time">모든 스텝의 시간을 1초 이상으로 설정해주세요.</string>
+    <string name="custom_timer_error_invalid_time">스텝의 시간을 1초 이상으로 설정해주세요.</string>
     <string name="custom_timer_error_max_steps">스텝은 50개까지 추가할 수 있어요.</string>
+    <string name="custom_timer_error_no_changes">변경사항이 없습니다.</string>
 
     <string name="error_failed_to_load_list">타이머를 불러오는데 실패했습니다.</string>
     <string name="custom_timer_error_create_failed">타이머를 생성하는데 실패했습니다.</string>

--- a/presentation/src/main/java/com/project200/presentation/view/MenuBottomSheetDialog.kt
+++ b/presentation/src/main/java/com/project200/presentation/view/MenuBottomSheetDialog.kt
@@ -15,7 +15,6 @@ import com.project200.undabang.presentation.databinding.BottomSheetDialogMenuBin
 class MenuBottomSheetDialog(
     val onEditClicked: () -> Unit,
     val onDeleteClicked: () -> Unit,
-    private val isEditVisible: Boolean = true, // TODO: 타이머 수정 기능이 추가되면 제거 예정
 ) : BottomSheetDialogFragment() {
     private var _binding: BottomSheetDialogMenuBinding? = null
     private val binding get() = _binding!!
@@ -47,8 +46,6 @@ class MenuBottomSheetDialog(
         }
 
         binding.closeBtn.setOnClickListener { dismiss() }
-
-        binding.editBtn.visibility = if (isEditVisible) View.VISIBLE else View.GONE // TODO: 타이머 수정 기능이 추가되면 제거 예정
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#259 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

수정 화면으로 이동 구현

커스텀 타이머 api 연결
- 변경 사항이 없으면 토스트 메세지를 출력합니다.
- 스텝 변경 사항이 있다면 전체 수정 api를 호출합니다.
- 타이머 이름만 변경된다면 이름 변경 api를 호출합니다.

CustomTimerFragment에서 데이터 갱신을 위해 setId와 loadData를 분리해서 onResume에서 갱신할 수 있도록 수정했습니다.

89f3902420f49f60019ecff2ca4b0bae610c7736
BindingFragment에서 onViewCreated에 이미 setupObservers가 있어서 삭제했습니다.
BindingFragment에서 onViewCreated에서 setupViews를 호출하고 있어서 onCreate에서 id를 먼저 설정하도록 변경했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?