### PR TITLE
[Fix] 닉네임 중복 에러 메세지 수정 #277

### DIFF
--- a/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
@@ -8,5 +8,5 @@ interface AuthRepository {
     suspend fun checkIsRegistered(): Boolean
     suspend fun login(): BaseResult<Unit>
     suspend fun logout(): BaseResult<Unit>
-    suspend fun signUp(gender: String, nickname: String, birth: LocalDate): SignUpResult
+    suspend fun signUp(gender: String, nickname: String, birth: LocalDate): BaseResult<Unit>
 }

--- a/domain/src/main/java/com/project200/domain/usecase/SignUpUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/SignUpUseCase.kt
@@ -1,5 +1,6 @@
 package com.project200.domain.usecase
 
+import com.project200.domain.model.BaseResult
 import com.project200.domain.model.SignUpResult
 import com.project200.domain.repository.AuthRepository
 import java.time.LocalDate
@@ -12,7 +13,7 @@ class SignUpUseCase @Inject constructor(
         gender: String,
         nickname: String,
         birth: LocalDate
-    ): SignUpResult {
+    ): BaseResult<Unit> {
         return authRepository.signUp(gender, nickname, birth)
     }
 }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -89,6 +89,10 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
                         appNavigator.navigateToMain(requireContext())
                     }
                     is SignUpResult.Failure -> {
+                        when(signUpResult.errorCode) {
+                            NICKNAME_DUPLICATE_ERROR -> Toast.makeText(requireContext(), getString(R.string.error_nickname_duplicated), Toast.LENGTH_LONG).show()
+                            else -> Toast.makeText(requireContext(), getString(R.string.error_unknown), Toast.LENGTH_LONG).show()
+                        }
                         Toast.makeText(requireContext(), signUpResult.errorMessage, Toast.LENGTH_LONG).show()
                     }
                 }
@@ -110,6 +114,7 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
     }
 
     companion object {
+        const val NICKNAME_DUPLICATE_ERROR = "409"
         const val MALE = "M"
         const val FEMALE = "F"
         const val HIDDEN = "U"

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -91,7 +91,7 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
                 is BaseResult.Error -> {
                     when(result.errorCode) {
                         NICKNAME_DUPLICATE_ERROR -> {
-                            Toast.makeText(requireContext(), "이미 사용 중인 닉네임입니다.", Toast.LENGTH_LONG).show()
+                            Toast.makeText(requireContext(), getString(R.string.error_nickname_duplicated), Toast.LENGTH_LONG).show()
                         }
                         ERROR_CODE_INVALID_NICKNAME -> {
                             Toast.makeText(requireContext(), getString(R.string.error_nickname_invalid), Toast.LENGTH_LONG).show()

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -85,7 +85,7 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
         signUpResult.observe(viewLifecycleOwner) { result ->
             when (result) {
                 is BaseResult.Success -> {
-                    Toast.makeText(requireContext(), "회원가입 성공!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.register_success), Toast.LENGTH_SHORT).show()
                     appNavigator.navigateToMain(requireContext())
                 }
                 is BaseResult.Error -> {

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -7,6 +7,7 @@ import androidx.core.view.marginStart
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import com.project200.common.utils.ClockProvider
+import com.project200.domain.model.BaseResult
 import com.project200.domain.model.SignUpResult
 import com.project200.presentation.base.BindingFragment
 import com.project200.presentation.navigator.ActivityNavigator
@@ -82,18 +83,25 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
         }
 
         signUpResult.observe(viewLifecycleOwner) { result ->
-            result?.let { signUpResult ->
-                when (signUpResult) {
-                    is SignUpResult.Success -> {
-                        Toast.makeText(requireContext(), "회원가입 성공!", Toast.LENGTH_SHORT).show()
-                        appNavigator.navigateToMain(requireContext())
-                    }
-                    is SignUpResult.Failure -> {
-                        when(signUpResult.errorCode) {
-                            NICKNAME_DUPLICATE_ERROR -> Toast.makeText(requireContext(), getString(R.string.error_nickname_duplicated), Toast.LENGTH_LONG).show()
-                            else -> Toast.makeText(requireContext(), getString(R.string.error_unknown), Toast.LENGTH_LONG).show()
+            when (result) {
+                is BaseResult.Success -> {
+                    Toast.makeText(requireContext(), "회원가입 성공!", Toast.LENGTH_SHORT).show()
+                    appNavigator.navigateToMain(requireContext())
+                }
+                is BaseResult.Error -> {
+                    when(result.errorCode) {
+                        NICKNAME_DUPLICATE_ERROR -> {
+                            Toast.makeText(requireContext(), "이미 사용 중인 닉네임입니다.", Toast.LENGTH_LONG).show()
                         }
-                        Toast.makeText(requireContext(), signUpResult.errorMessage, Toast.LENGTH_LONG).show()
+                        ERROR_CODE_INVALID_NICKNAME -> {
+                            Toast.makeText(requireContext(), getString(R.string.error_nickname_invalid), Toast.LENGTH_LONG).show()
+                        }
+                        FORM_INCOMPLETE -> {
+                            Toast.makeText(requireContext(), getString(R.string.error_form_incomplete), Toast.LENGTH_LONG).show()
+                        }
+                        else -> {
+                            Toast.makeText(requireContext(), getString(R.string.error_unknown), Toast.LENGTH_LONG).show()
+                        }
                     }
                 }
             }
@@ -119,5 +127,7 @@ class RegisterFragment : BindingFragment<FragmentRegisterBinding>(R.layout.fragm
         const val FEMALE = "F"
         const val HIDDEN = "U"
         const val FONT_SCALE_THRESHOLD = 1.5f // 폰트 크기 임계값
+        const val ERROR_CODE_INVALID_NICKNAME = "INVALID_NICKNAME"
+        const val FORM_INCOMPLETE = "FORM_INCOMPLETE"
     }
 }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterViewModel.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterViewModel.kt
@@ -66,7 +66,7 @@ class RegisterViewModel @Inject constructor(
         if (!validateNicknameUseCase(currentNickname)) {
             _signUpResult.value = BaseResult.Error(
                 errorCode = ERROR_CODE_INVALID_NICKNAME,
-                message = ERROR_MESSAGE_INVALID_NICKNAME,
+                message = "",
                 cause = null
             )
             return
@@ -75,7 +75,7 @@ class RegisterViewModel @Inject constructor(
         if (currentGender == null || currentBirthStr == null) {
             _signUpResult.value = BaseResult.Error(
                 errorCode = FORM_INCOMPLETE,
-                message = ERROR_MESSAGE_FORM_INCOMPLETE,
+                message = "",
                 cause = null
             )
             return
@@ -101,9 +101,6 @@ class RegisterViewModel @Inject constructor(
 
     companion object {
         const val ERROR_CODE_INVALID_NICKNAME = "INVALID_NICKNAME"
-        const val ERROR_MESSAGE_INVALID_NICKNAME = "닉네임 조건을 확인해주세요."
-        const val ERROR_MESSAGE_FORM_INCOMPLETE = "생일과 성별을 모두 선택해주세요."
-        const val ERROR_MESSAGE_NICKNAME_DUPLICATED = "이미 사용 중인 닉네임입니다."
         const val FORM_INCOMPLETE = "FORM_INCOMPLETE"
     }
 }

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="hidden">공개 안함</string>
     <string name="birth_default">YYYY / MM / DD</string>
     <string name="error_nickname_duplicated">이미 사용 중인 닉네임입니다.</string>
+    <string name="error_nickname_invalid">닉네임 조건을 확인해주세요.</string>
+    <string name="error_form_incomplete">생일과 성별을 모두 선택해주세요.</string>
     <string name="error_unknown">알 수 없는 오류가 발생했습니다.</string>
 
     <!-- 에러 -->

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="error_nickname_invalid">닉네임 조건을 확인해주세요.</string>
     <string name="error_form_incomplete">생일과 성별을 모두 선택해주세요.</string>
     <string name="error_unknown">알 수 없는 오류가 발생했습니다.</string>
+    <string name="register_success">회원가입 성공!</string>
 
     <!-- 에러 -->
     <string name="login_failed">로그인에 실패했습니다.</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#277 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

닉네임 중복 시 에러 메세지를 띄우도록 버그 수정 (기존: 알 수 없는 에러)
응답을 BaseResult를 사용하도록 변경했습니다.
에러 메세지를 Fragment에서 처리하도록 변경했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?