### PR TITLE
[Feat] 검색 결과 리스트 화면 구현 #315

### DIFF
--- a/data/src/main/java/com/project200/data/api/KakaoApiService.kt
+++ b/data/src/main/java/com/project200/data/api/KakaoApiService.kt
@@ -23,6 +23,16 @@ interface KakaoApiService {
         @Query("y") latitude: Double,
         @Query("x") longitude: Double,
         @Query("radius") radius: Int,
-        @Query("sort") sort: String = "distance" // 거리순 정렬
+        @Query("sort") sort: String = "distance"
+    ): KakaoKeywordSearchResponse
+
+    // 카카오 키워드로 검색
+    @GET("/v2/local/search/keyword.json")
+    @Named("kakao")
+    suspend fun searchPlacesByKeyword(
+        @Query("query") query: String,
+        @Query("y") latitude: Double,
+        @Query("x") longitude: Double,
+        @Query("sort") sort: String = "distance"
     ): KakaoKeywordSearchResponse
 }

--- a/data/src/main/java/com/project200/data/dto/KakaoAddressDTO.kt
+++ b/data/src/main/java/com/project200/data/dto/KakaoAddressDTO.kt
@@ -36,6 +36,8 @@ data class KakaoKeywordSearchResponse(
 data class PlaceDocument(
     @Json(name = "place_name") val placeName: String,
     @Json(name = "address_name") val addressName: String,
-    @Json(name = "road_address_name") val roadAddressName: String
+    @Json(name = "road_address_name") val roadAddressName: String,
+    @Json(name = "x") val longitude: String,
+    @Json(name = "y") val latitude: String,
 )
 

--- a/data/src/main/java/com/project200/data/impl/AddressRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AddressRepositoryImpl.kt
@@ -20,12 +20,20 @@ class AddressRepositoryImpl @Inject constructor(
      * 3. 가까운 장소가 없다면, '좌표->주소 변환' API를 호출하여 도로명 주소 또는 지번 주소를 사용합니다.
      * @return API 호출 결과를 BaseResult<PlaceInfo> 형태로 반환
      */
-    override suspend fun getAddressFromCoordinates(latitude: Double, longitude: Double): BaseResult<KakaoPlaceInfo> {
+    override suspend fun getAddressFromCoordinates(
+        latitude: Double,
+        longitude: Double
+    ): BaseResult<KakaoPlaceInfo> {
         return externalApiCallBuilder(
             ioDispatcher = ioDispatcher,
             apiCall = {
                 // 키워드로 주변 장소 검색 api를 호출합니다.
-                val nearestPlace = kakaoApiService.searchNearbyPlaces("", latitude, longitude, 20).documents.firstOrNull()
+                val nearestPlace = kakaoApiService.searchNearbyPlaces(
+                    "",
+                    latitude,
+                    longitude,
+                    20
+                ).documents.firstOrNull()
 
                 if (nearestPlace != null) {
                     // 가까운 장소를 찾았다면, 이 정보를 사용합니다.
@@ -36,11 +44,14 @@ class AddressRepositoryImpl @Inject constructor(
                     }
                     KakaoPlaceInfo(
                         placeName = nearestPlace.placeName,
-                        address = finalAddress
+                        address = finalAddress,
+                        latitude = latitude,
+                        longitude = longitude
                     )
                 } else {
                     // 가까운 장소가 없다면, '좌표->주소 변환' API를 호출합니다.
-                    val addressResponse = kakaoApiService.getAddressFromCoordinates(longitude, latitude)
+                    val addressResponse =
+                        kakaoApiService.getAddressFromCoordinates(longitude, latitude)
                     val addressDocument = addressResponse.documents.firstOrNull()
                         ?: throw NoSuchElementException()
 
@@ -49,19 +60,54 @@ class AddressRepositoryImpl @Inject constructor(
                         // 도로명 주소가 있으면 사용합니다.
                         KakaoPlaceInfo(
                             placeName = roadAddress.buildingName,
-                            address = roadAddress.addressName
+                            address = roadAddress.addressName,
+                            latitude = latitude,
+                            longitude = longitude
                         )
                     } else {
                         // 도로명 주소가 없으면 지번 주소를 사용합니다.
                         val jibunAddress = addressDocument.address ?: throw NoSuchElementException()
                         KakaoPlaceInfo(
                             placeName = jibunAddress.addressName,
-                            address = jibunAddress.addressName
+                            address = jibunAddress.addressName,
+                            latitude = latitude,
+                            longitude = longitude
                         )
                     }
                 }
             },
             mapper = { placeInfo: KakaoPlaceInfo -> placeInfo }
+        )
+    }
+
+    override suspend fun getPlacesByKeyword(
+        query: String,
+        latitude: Double,
+        longitude: Double
+    ): BaseResult<List<KakaoPlaceInfo>> {
+        return externalApiCallBuilder(
+            ioDispatcher = ioDispatcher,
+            apiCall = {
+                val response = kakaoApiService.searchPlacesByKeyword(
+                    query = query,
+                    latitude = latitude,
+                    longitude = longitude
+                )
+                response.documents.map { document ->
+                    val finalAddress = if (document.roadAddressName.isNotBlank()) {
+                        document.roadAddressName
+                    } else {
+                        document.addressName
+                    }
+                    KakaoPlaceInfo(
+                        placeName = document.placeName,
+                        address = finalAddress,
+                        latitude = document.latitude.toDouble(),
+                        longitude = document.longitude.toDouble()
+                    )
+                }
+            },
+            mapper = { places: List<KakaoPlaceInfo> -> places }
         )
     }
 }

--- a/domain/src/main/java/com/project200/domain/model/AddressModel.kt
+++ b/domain/src/main/java/com/project200/domain/model/AddressModel.kt
@@ -2,5 +2,7 @@ package com.project200.domain.model
 
 data class KakaoPlaceInfo(
     val placeName: String,
-    val address: String
+    val address: String,
+    val latitude: Double,
+    val longitude: Double
 )

--- a/domain/src/main/java/com/project200/domain/repository/AddressRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/AddressRepository.kt
@@ -9,4 +9,10 @@ interface AddressRepository {
      * @return API 호출 결과를 BaseResult<PlaceInfo> 형태로 반환
      */
     suspend fun getAddressFromCoordinates(latitude: Double, longitude: Double): BaseResult<KakaoPlaceInfo>
+
+    /**
+     * 키워드로 장소를 검색합니다.
+     * @return API 호출 결과를 BaseResult<List<PlaceInfo>> 형태로 반환
+     */
+    suspend fun getPlacesByKeyword(query: String, latitude: Double, longitude: Double): BaseResult<List<KakaoPlaceInfo>>
 }

--- a/domain/src/main/java/com/project200/domain/usecase/GetPlacesByKeywordUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/GetPlacesByKeywordUseCase.kt
@@ -1,0 +1,14 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.model.BaseResult
+import com.project200.domain.model.KakaoPlaceInfo
+import com.project200.domain.repository.AddressRepository
+import javax.inject.Inject
+
+class GetPlacesByKeywordUseCase @Inject constructor(
+    private val addressRepository: AddressRepository
+) {
+    suspend operator fun invoke(query: String, latitude: Double, longitude: Double): BaseResult<List<KakaoPlaceInfo>> {
+        return addressRepository.getPlacesByKeyword(query, latitude, longitude)
+    }
+}

--- a/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceSearchViewModel.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceSearchViewModel.kt
@@ -10,6 +10,7 @@ import com.project200.domain.model.KakaoPlaceInfo
 import com.project200.domain.usecase.DeleteExercisePlaceUseCase
 import com.project200.domain.usecase.GetAddressFromCoordinatesUseCase
 import com.project200.domain.usecase.GetExercisePlaceUseCase
+import com.project200.domain.usecase.GetPlacesByKeywordUseCase
 import com.project200.feature.matching.utils.ExercisePlaceErrorType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -19,11 +20,18 @@ import javax.inject.Inject
 class ExercisePlaceSearchViewModel
 @Inject
 constructor(
-    private val getAddressFromCoordinatesUseCase: GetAddressFromCoordinatesUseCase
+    private val getAddressFromCoordinatesUseCase: GetAddressFromCoordinatesUseCase,
+    private val searchPlacesByKeywordUseCase: GetPlacesByKeywordUseCase,
 ) : ViewModel() {
+
+    private val _place = MutableLiveData<KakaoPlaceInfo>()
+    val place: LiveData<KakaoPlaceInfo> = _place
 
     private val _placeInfoResult = MutableLiveData<BaseResult<KakaoPlaceInfo>>()
     val placeInfoResult: LiveData<BaseResult<KakaoPlaceInfo>> = _placeInfoResult
+
+    private val _searchResult = MutableLiveData<BaseResult<List<KakaoPlaceInfo>>>()
+    val searchResult: LiveData<BaseResult<List<KakaoPlaceInfo>>> = _searchResult
 
     /**
      * 주어진 위도와 경도를 사용하여 주소 정보를 가져옵니다.
@@ -32,5 +40,18 @@ constructor(
         viewModelScope.launch {
             _placeInfoResult.value = getAddressFromCoordinatesUseCase(latitude, longitude)
         }
+    }
+
+    /**
+     * 키워드로 장소를 검색합니다.
+     */
+    fun searchPlacesByKeyword(query: String, latitude: Double, longitude: Double) {
+        viewModelScope.launch {
+            _searchResult.value = searchPlacesByKeywordUseCase(query, latitude, longitude)
+        }
+    }
+
+    fun setPlace(place: KakaoPlaceInfo) {
+        _place.value = place
     }
 }

--- a/feature/matching/src/main/java/com/project200/feature/matching/place/SearchedPlaceRVAdapter.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/place/SearchedPlaceRVAdapter.kt
@@ -1,0 +1,41 @@
+package com.project200.feature.matching.place
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.project200.domain.model.KakaoPlaceInfo
+import com.project200.undabang.feature.matching.databinding.ItemSearchedPlaceBinding
+
+class SearchedPlaceRVAdapter(
+    private val onItemClick: (KakaoPlaceInfo) -> Unit
+) : RecyclerView.Adapter<SearchedPlaceRVAdapter.SearchedPlaceViewHolder>() {
+
+    private var items: List<KakaoPlaceInfo> = emptyList()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchedPlaceViewHolder {
+        val binding = ItemSearchedPlaceBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return SearchedPlaceViewHolder(binding, onItemClick)
+    }
+
+    override fun onBindViewHolder(holder: SearchedPlaceViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(newItems: List<KakaoPlaceInfo>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+
+    class SearchedPlaceViewHolder(
+        private val binding: ItemSearchedPlaceBinding,
+        private val onItemClick: (KakaoPlaceInfo) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: KakaoPlaceInfo) {
+            binding.placeNameTv.text = item.placeName
+            binding.placeAddressTv.text = item.address
+            itemView.setOnClickListener { onItemClick(item) }
+        }
+    }
+}

--- a/feature/matching/src/main/res/drawable/bg_exercise_place.xml
+++ b/feature/matching/src/main/res/drawable/bg_exercise_place.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white300"/>
+        </shape>
+    </item>
+    <item android:gravity="bottom">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray300"/>
+            <size android:height="1dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/feature/matching/src/main/res/layout/fragment_exercise_place_search.xml
+++ b/feature/matching/src/main/res/layout/fragment_exercise_place_search.xml
@@ -23,11 +23,14 @@
             android:visibility="visible" />
 
         <EditText
+            android:id="@+id/search_exercise_place_et"
             android:layout_width="0dp"
             android:layout_height="40dp"
             android:layout_marginStart="4dp"
             android:layout_marginEnd="12dp"
             android:layout_weight="1"
+            android:maxLines="1"
+            android:inputType="text"
             android:background="@drawable/bg_solid_corner"
             android:drawableStart="@drawable/ic_search"
             android:drawablePadding="12dp"
@@ -110,4 +113,29 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
     </LinearLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/searched_place_cl"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:background="@color/white300"
+        app:layout_constraintTop_toBottomOf="@id/search_toolbar_ll"
+        app:layout_constraintBottom_toBottomOf="parent">
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/searched_place_rv"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"/>
+        <TextView
+            android:id="@+id/searched_place_empty_tv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            style="@style/content_regular"
+            android:gravity="center"
+            android:visibility="gone"
+            android:text="@string/empty_searched_place"
+            android:textColor="@color/gray200"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/matching/src/main/res/layout/item_searched_place.xml
+++ b/feature/matching/src/main/res/layout/item_searched_place.xml
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
+    android:layout_height="80dp"
     android:background="@drawable/bg_exercise_place"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:paddingHorizontal="@dimen/base_horizontal_margin">
-    <ImageView
-        android:id="@+id/place_iv"
-        android:src="@drawable/ic_member_marker"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:tint="@color/black" />
     <TextView
         android:id="@+id/place_name_tv"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toEndOf="@id/place_iv"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/place_address_tv"
         app:layout_constraintVertical_chainStyle="packed"
-        style="@style/content_bold"
+        style="@style/medium_bold"
         android:layout_marginBottom="8dp"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="@dimen/base_horizontal_margin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
     <TextView
@@ -30,16 +21,8 @@
         app:layout_constraintTop_toBottomOf="@id/place_name_tv"
         app:layout_constraintStart_toStartOf="@id/place_name_tv"
         app:layout_constraintBottom_toBottomOf="parent"
-        style="@style/subtext_12"
+        style="@style/subtext_14"
         android:textColor="@color/gray100"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
-    <ImageView
-        android:id="@+id/menu_iv"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:src="@drawable/ic_menu"
-        android:layout_margin="@dimen/base_horizontal_margin"
-        android:layout_width="20dp"
-        android:layout_height="20dp"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/matching/src/main/res/values/string.xml
+++ b/feature/matching/src/main/res/values/string.xml
@@ -36,4 +36,8 @@
     <string name="error_failed_to_load_exercise_place">운동 장소 목록을 불러오는데 실패했습니다.</string>
     <string name="error_failed_to_delete_exercise_place">운동 장소 삭제에 실패했습니다.</string>
     <string name="error_cannot_find_address">주소를 가져오는데 실패했습니다.</string>
+
+    <string name="no_search_keyword">검색어를 입력해주세요.</string>
+    <string name="empty_searched_place">검색 결과가 없습니다.</string>
+    <string name="error_failed_to_search_place">검색 중 오류가 발생했습니다.</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#315 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

카카오 키워드로 검색 api 연결
- 사용자가 보고있는 지도의 중심점 좌표를 기준으로 거리순으로 키워드 검색 결과가 반환됩니다.
- 키워드로 검색한 결과 리스트를 RecyclerVIew에 반영합니다.
- 아이템을 선택하면 지도에 반영됩니다.
- 기존 KakaoPlaceInfo에 위도, 경도 파라미터를 추가했습니다.

### 스크린샷 (선택)

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/a9b3cb15-d2a3-4869-b70b-7353f7aa4845" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?