### PR TITLE
feat: 멤버 id 저장 및 채팅 수신 시 비교 로직 추가 #426

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -56,6 +56,7 @@ class MainViewModel
         fun login() {
             viewModelScope.launch {
                 val result = loginUseCase()
+                checkIsRegisteredUseCase()
                 _loginResult.value = result
             }
         }

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -27,6 +27,7 @@ class AuthRepositoryImpl
             withContext(ioDispatcher) {
                 try {
                     val response = apiService.getIsRegistered()
+                    response.data?.let { spManager.saveMemberId(it.memberId) }
                     response.data?.isRegistered ?: false
                 } catch (e: CancellationException) {
                     throw e
@@ -79,6 +80,10 @@ class AuthRepositoryImpl
                     dto?.available == true
                 },
             )
+        }
+
+        override suspend fun getMemberId(): String {
+            return spManager.getMemberId().toString()
         }
 
         companion object {

--- a/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
@@ -9,4 +9,5 @@ interface AuthRepository {
     suspend fun logout(): BaseResult<Unit>
     suspend fun signUp(gender: String, nickname: String, birth: LocalDate): BaseResult<Unit>
     suspend fun checkNicknameDuplicated(nickname: String): BaseResult<Boolean>
+    suspend fun getMemberId(): String
 }

--- a/domain/src/main/java/com/project200/domain/usecase/GetMemberIdUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/GetMemberIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class GetMemberIdUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(): String {
+        return authRepository.getMemberId()
+    }
+}

--- a/feature/chatting/src/main/java/com/project200/feature/chatting/chattingRoom/ChattingRoomViewModel.kt
+++ b/feature/chatting/src/main/java/com/project200/feature/chatting/chattingRoom/ChattingRoomViewModel.kt
@@ -52,7 +52,6 @@ class ChattingRoomViewModel
 
         init {
             viewModelScope.launch {
-                // TODO: 내 memberId 저장
                 observeSocketMessagesUseCase().collect { chat ->
                     // 리스트에 추가
                     addMessage(chat)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#426 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- memberId 저장 로직 추가
  - 현재는 로그인 시에 memberId가 반환되지 않아서 임시로 checkIsRegistered api의 응답값으로 받아서 저장했습니다.
  - 추후에 로그인 혹은 채팅방 접속할 때 받도록 수정될 예정입니다
- 채팅 수신 시 비교 로직 추가
  - 기존에는 mine boolean 변수로 상대방과 내 채팅을 구분했었는데, 웹소켓으로 리팩토링하면서 삭제됐습니다.
  - 이전에 저장해놓은 memberId와 senderId를 비교하는 방식으로 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?