### PR TITLE
feat: 기록 메인 화면으로 타이머 진입점 변경 #483

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -129,6 +129,7 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
                 com.project200.undabang.feature.exercise.R.id.exerciseDetailFragment,
                 com.project200.undabang.feature.exercise.R.id.exerciseFormFragment,
                 com.project200.undabang.feature.exercise.R.id.exerciseListFragment,
+                com.project200.undabang.feature.timer.R.id.timerListFragment,
                 com.project200.undabang.feature.timer.R.id.simpleTimerFragment,
                 com.project200.undabang.feature.timer.R.id.customTimerFragment,
                 com.project200.undabang.feature.timer.R.id.customTimerFormFragment,

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -16,10 +16,6 @@
         android:id="@id/chatting_nav_graph"
         android:icon="@drawable/ic_chatting"
         android:title="@string/chatting"/>
-    <!--    <item-->
-<!--        android:id="@id/timer_nav_graph"-->
-<!--        android:icon="@drawable/ic_nav_timer"-->
-<!--        android:title="@string/timer" />-->
     <item
         android:id="@id/profile_nav_graph"
         android:icon="@drawable/ic_nav_mypage"

--- a/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/main/ExerciseMainFragment.kt
@@ -1,5 +1,6 @@
 package com.project200.feature.exercise.main
 
+import android.net.Uri
 import android.view.View
 import android.widget.Toast
 import androidx.core.content.ContextCompat.getColor
@@ -168,6 +169,10 @@ class ExerciseMainFragment : BindingFragment<FragmentExerciseMainBinding>(R.layo
             viewModel.scorePolicy.value?.let {
                 ScorePolicyDialog().show(childFragmentManager, "ScorePolicyDialog")
             }
+        }
+
+        binding.timerBtn.setOnClickListener {
+            findNavController().navigate(Uri.parse("app://timer"))
         }
     }
 

--- a/feature/exercise/src/main/res/drawable/bg_timer_chip.xml
+++ b/feature/exercise/src/main/res/drawable/bg_timer_chip.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/main_background" />
+    <corners android:radius="20dp" />
+    <padding
+        android:left="14dp"
+        android:top="8dp"
+        android:right="14dp"
+        android:bottom="8dp" />
+</shape>

--- a/feature/exercise/src/main/res/layout/fragment_exercise_main.xml
+++ b/feature/exercise/src/main/res/layout/fragment_exercise_main.xml
@@ -30,6 +30,32 @@
                     android:src="@drawable/ic_logo_appname"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
+                <LinearLayout
+                    android:id="@+id/timer_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_timer_chip"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    app:layout_constraintBottom_toBottomOf="@id/logo_iv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/logo_iv">
+
+                    <ImageView
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:src="@drawable/ic_nav_timer"
+                        app:tint="@color/main" />
+
+                    <TextView
+                        style="@style/subtext_14"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:text="@string/timer"
+                        android:textColor="@color/main" />
+                </LinearLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/feature/timer/src/main/java/com/project200/feature/timer/TimerListFragment.kt
+++ b/feature/timer/src/main/java/com/project200/feature/timer/TimerListFragment.kt
@@ -26,8 +26,16 @@ class TimerListFragment : BindingFragment<FragmentTimerListBinding>(R.layout.fra
 
     override fun setupViews() {
         super.setupViews()
+        initToolbar()
         initClickListeners()
         initRecyclerView()
+    }
+
+    private fun initToolbar() {
+        binding.baseToolbar.apply {
+            setTitle(getString(R.string.timer_title))
+            showBackButton(true) { findNavController().navigateUp() }
+        }
     }
 
     private fun initClickListeners() {

--- a/feature/timer/src/main/res/layout/fragment_timer_list.xml
+++ b/feature/timer/src/main/res/layout/fragment_timer_list.xml
@@ -6,23 +6,20 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/main_background">
 
+    <com.project200.presentation.base.BaseToolbar
+        android:id="@+id/base_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/base_toolbar">
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:paddingTop="@dimen/base_horizontal_margin"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <ImageView
-                android:id="@+id/logo_iv"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/base_horizontal_margin"
-                android:src="@drawable/ic_logo_appname"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/simple_timer_btn"
@@ -36,7 +33,7 @@
                 android:gravity="center"
                 android:text="@string/simple_timer"
                 android:textColor="@color/white300"
-                app:layout_constraintTop_toBottomOf="@id/logo_iv" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:layout_width="24dp"

--- a/feature/timer/src/main/res/navigation/timer_nav_graph.xml
+++ b/feature/timer/src/main/res/navigation/timer_nav_graph.xml
@@ -10,6 +10,7 @@
         android:name="com.project200.feature.timer.TimerListFragment"
         android:label="TimerListFragment"
         tools:layout="@layout/fragment_timer_list" >
+        <deepLink app:uri="app://timer" />
         <action
             android:id="@+id/action_timerListFragment_to_simpleTimerFragment"
             app:destination="@id/simpleTimerFragment" />

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="timer_title">타이머</string>
     <string name="simple_timer">심플 타이머</string>
     <string name="custom_timer_default">나만의 타이머</string>
     


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 타이머 진입점 변경

- 바텀 네비게이션에서 타이머 탭 제거
- 기록 메인화면 상단 우측에 타이머 버튼 추가 (딥링크 방식 모듈 간 네비게이션)
- 타이머 메인화면 로고를 BaseToolbar로 교체
- 타이머 화면 진입 시 바텀 네비게이션 숨김 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?