### PR TITLE
[Fix] 피드 다방 필터링 오류 수정 #486

### DIFF
--- a/feature/feed/src/main/java/com/project200/undabang/feature/feed/list/FeedListFragment.kt
+++ b/feature/feed/src/main/java/com/project200/undabang/feature/feed/list/FeedListFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.project200.domain.model.ExerciseType
 import com.project200.presentation.base.BindingFragment
 import com.project200.presentation.utils.collectToast
 import com.project200.presentation.view.SelectionBottomSheetDialog
@@ -74,8 +75,10 @@ class FeedListFragment : BindingFragment<FragmentFeedListBinding>(R.layout.fragm
         viewModel.requestShowCategoryBottomSheet()
     }
 
-    private fun displayCategoryBottomSheet(items: List<String>) {
-        SelectionBottomSheetDialog(items) { selectedType ->
+    private fun displayCategoryBottomSheet(exerciseTypes: List<ExerciseType>) {
+        val names = exerciseTypes.map { it.name }
+        SelectionBottomSheetDialog(names) { selectedName ->
+            val selectedType = exerciseTypes.find { it.name == selectedName }
             viewModel.selectType(selectedType)
         }.show(parentFragmentManager, SelectionBottomSheetDialog::class.java.name)
         viewModel.onCategoryBottomSheetShown()
@@ -120,16 +123,16 @@ class FeedListFragment : BindingFragment<FragmentFeedListBinding>(R.layout.fragm
             binding.emptyTv.visibility = if (showEmpty) View.VISIBLE else View.GONE
         }
 
-        viewModel.showCategoryBottomSheet.observe(viewLifecycleOwner) { items ->
-            if (!items.isNullOrEmpty()) {
-                displayCategoryBottomSheet(items)
+        viewModel.showCategoryBottomSheet.observe(viewLifecycleOwner) { exerciseTypes ->
+            if (!exerciseTypes.isNullOrEmpty()) {
+                displayCategoryBottomSheet(exerciseTypes)
             }
         }
 
         viewModel.selectedType.observe(viewLifecycleOwner) { type ->
             binding.baseToolbar.apply {
                 if (type != null) {
-                    setTitle(type)
+                    setTitle(type.name)
                     setSecondarySubButton(null)
                     showBackButton(true) { viewModel.clearType() }
                 } else {

--- a/feature/feed/src/main/java/com/project200/undabang/feature/feed/list/FeedListViewModel.kt
+++ b/feature/feed/src/main/java/com/project200/undabang/feature/feed/list/FeedListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.project200.domain.model.BaseResult
+import com.project200.domain.model.ExerciseType
 import com.project200.domain.model.Feed
 import com.project200.domain.usecase.DeleteFeedUseCase
 import com.project200.domain.usecase.GetFeedsUseCase
@@ -33,8 +34,8 @@ class FeedListViewModel
         private val _feedList = MutableLiveData<List<Feed>>()
         val feedList: LiveData<List<Feed>> get() = _feedList
 
-        private val _selectedType = MutableLiveData<String?>(null)
-        val selectedType: LiveData<String?> = _selectedType
+        private val _selectedType = MutableLiveData<ExerciseType?>(null)
+        val selectedType: LiveData<ExerciseType?> = _selectedType
 
         private val _isLoading = MutableLiveData<Boolean>(false)
         val isLoading: LiveData<Boolean> get() = _isLoading
@@ -45,8 +46,8 @@ class FeedListViewModel
         private val _isEmpty = MutableLiveData<Boolean>(false)
         val isEmpty: LiveData<Boolean> get() = _isEmpty
 
-        private val _exerciseTypeList = MutableLiveData<List<String>>()
-        val exerciseTypeList: LiveData<List<String>> = _exerciseTypeList
+        private val _exerciseTypeList = MutableLiveData<List<ExerciseType>>()
+        val exerciseTypeList: LiveData<List<ExerciseType>> = _exerciseTypeList
 
         private val _currentMemberId = MutableLiveData<String>()
         val currentMemberId: LiveData<String> get() = _currentMemberId
@@ -54,8 +55,8 @@ class FeedListViewModel
         private val _showEmptyView = MutableLiveData<Boolean>(false)
         val showEmptyView: LiveData<Boolean> get() = _showEmptyView
 
-        private val _showCategoryBottomSheet = MutableLiveData<List<String>?>()
-        val showCategoryBottomSheet: LiveData<List<String>?> get() = _showCategoryBottomSheet
+        private val _showCategoryBottomSheet = MutableLiveData<List<ExerciseType>?>()
+        val showCategoryBottomSheet: LiveData<List<ExerciseType>?> get() = _showCategoryBottomSheet
 
         private var hasNext: Boolean = true
         private var lastFeedId: Long? = null
@@ -77,7 +78,7 @@ class FeedListViewModel
             }
         }
 
-        fun selectType(type: String?) {
+        fun selectType(type: ExerciseType?) {
             _selectedType.value = type
             updateFilteredList()
         }
@@ -109,11 +110,11 @@ class FeedListViewModel
         }
 
         private fun updateFilteredList() {
-            val type = _selectedType.value
-            if (type == null) {
+            val selectedTypeId = _selectedType.value?.id
+            if (selectedTypeId == null) {
                 _feedList.value = allFeeds.toList()
             } else {
-                _feedList.value = allFeeds.filter { it.feedTypeName == type }
+                _feedList.value = allFeeds.filter { it.feedTypeId == selectedTypeId }
             }
         }
 
@@ -121,25 +122,26 @@ class FeedListViewModel
             if (!_exerciseTypeList.value.isNullOrEmpty()) return
             viewModelScope.launch {
                 val preferredResult = getPreferredExerciseUseCase()
-                val preferredNames =
+                val preferredTypes =
                     if (preferredResult is BaseResult.Success) {
-                        preferredResult.data.map { it.name }
+                        preferredResult.data.map { ExerciseType(it.exerciseTypeId, it.name, it.imageUrl) }
                     } else {
                         emptyList()
                     }
 
                 val allTypesResult = getPreferredExerciseTypesUseCase()
-                val allNames =
+                val allTypes =
                     if (allTypesResult is BaseResult.Success) {
-                        allTypesResult.data.map { it.name }
+                        allTypesResult.data.map { ExerciseType(it.exerciseTypeId, it.name, it.imageUrl) }
                     } else {
                         emptyList()
                     }
 
+                val preferredIds = preferredTypes.map { it.id }.toSet()
                 val combinedList =
-                    mutableListOf<String>().apply {
-                        addAll(preferredNames)
-                        addAll(allNames.filterNot { preferredNames.contains(it) })
+                    mutableListOf<ExerciseType>().apply {
+                        addAll(preferredTypes)
+                        addAll(allTypes.filterNot { preferredIds.contains(it.id) })
                     }
 
                 _exerciseTypeList.value = combinedList

--- a/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedDetailViewModelTest.kt
+++ b/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedDetailViewModelTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.Comment
+import com.project200.domain.model.CreateCommentResult
 import com.project200.domain.model.Feed
 import com.project200.domain.usecase.CreateCommentUseCase
 import com.project200.domain.usecase.DeleteCommentUseCase
@@ -14,6 +15,7 @@ import com.project200.domain.usecase.GetFeedDetailUseCase
 import com.project200.domain.usecase.GetMemberIdUseCase
 import com.project200.domain.usecase.LikeCommentUseCase
 import com.project200.domain.usecase.LikeFeedUseCase
+import com.project200.undabang.feature.feed.detail.CommentItem
 import com.project200.undabang.feature.feed.detail.FeedDetailViewModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -30,6 +32,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDateTime
 
 @ExperimentalCoroutinesApi
 class FeedDetailViewModelTest {
@@ -73,13 +76,16 @@ class FeedDetailViewModelTest {
         nickname = "테스터",
         feedTypeName = "헬스",
         feedTypeId = 1L,
+        feedTypeDesc = "헬스 운동",
         feedContent = "테스트 피드",
         feedPictures = emptyList(),
         feedLikesCount = 10,
         feedCommentsCount = 5,
         feedIsLiked = false,
-        createdAt = "2025-01-01T10:00:00",
-        thumbnailUrl = null
+        feedCreatedAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
+        feedHasCommented = false,
+        thumbnailUrl = null,
+        profileUrl = null
     )
 
     private val sampleComment = Comment(
@@ -87,12 +93,11 @@ class FeedDetailViewModelTest {
         memberId = "member1",
         memberNickname = "테스터",
         memberProfileImageUrl = null,
+        memberThumbnailUrl = null,
         content = "테스트 댓글",
         likesCount = 0,
         isLiked = false,
-        createdAt = "2025-01-01T10:00:00",
-        taggedMemberId = null,
-        taggedMemberNickname = null,
+        createdAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
         children = emptyList()
     )
 
@@ -148,9 +153,9 @@ class FeedDetailViewModelTest {
     }
 
     @Test
-    fun `setFeedId - 다른 사람 피드인 경우 isMyFeed가 false`() = runTest {
+    fun `setFeedId - 다른 사람의 피드인 경우 isMyFeed가 false`() = runTest {
         // Given
-        coEvery { getMemberIdUseCase() } returns "member2"
+        coEvery { getMemberIdUseCase() } returns "other_member"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
         coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
 
@@ -163,22 +168,22 @@ class FeedDetailViewModelTest {
     }
 
     @Test
-    fun `setFeedId - 피드 로드 실패 시 에러 이벤트 발생`() = runTest {
+    fun `setFeedId - 피드 로드 실패 시 토스트 이벤트를 발생시킨다`() = runTest {
         // Given
         coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Error("ERROR", "Failed")
         coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
 
         // When & Then
-        viewModel.feedLoadError.test {
+        viewModel.toastEvent.test {
             viewModel.setFeedId(1L)
             testDispatcher.scheduler.advanceUntilIdle()
-            assertThat(awaitItem()).isEqualTo(Unit)
+            assertThat(awaitItem()).isNotNull()
         }
     }
 
     @Test
-    fun `deleteFeed - 삭제 성공 시 feedDeleted 이벤트 발생`() = runTest {
+    fun `deleteFeed - 삭제 성공 시 feedDeleted 이벤트를 발생시킨다`() = runTest {
         // Given
         coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
@@ -196,12 +201,12 @@ class FeedDetailViewModelTest {
     }
 
     @Test
-    fun `deleteFeed - 삭제 실패 시 토스트 이벤트 발생`() = runTest {
+    fun `deleteFeed - 삭제 실패 시 토스트 이벤트를 발생시킨다`() = runTest {
         // Given
         coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
         coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
-        coEvery { deleteFeedUseCase(1L) } returns BaseResult.Error("ERROR", "Failed")
+        coEvery { deleteFeedUseCase(1L) } returns BaseResult.Error("ERROR", "Delete failed")
         viewModel.setFeedId(1L)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -236,7 +241,7 @@ class FeedDetailViewModelTest {
         coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
         coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
-        coEvery { createCommentUseCase(1L, "테스트", null, null) } returns BaseResult.Success(Unit)
+        coEvery { createCommentUseCase(1L, "테스트", null, null) } returns BaseResult.Success(CreateCommentResult(commentId = 1L))
         viewModel.setFeedId(1L)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -278,6 +283,7 @@ class FeedDetailViewModelTest {
 
         // When
         viewModel.toggleFeedLike()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
         assertThat(viewModel.feed.value?.feedIsLiked).isTrue()
@@ -285,39 +291,67 @@ class FeedDetailViewModelTest {
     }
 
     @Test
-    fun `toggleFeedLike - 디바운스 후 서버에 반영된다`() = runTest {
+    fun `toggleFeedLike - 좋아요 취소 시 카운트가 감소한다`() = runTest {
         // Given
+        val likedFeed = sampleFeed.copy(feedIsLiked = true, feedLikesCount = 10)
         coEvery { getMemberIdUseCase() } returns "member1"
-        coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
+        coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(likedFeed)
         coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
-        coEvery { likeFeedUseCase(1L, true) } returns BaseResult.Success(Unit)
+        coEvery { likeFeedUseCase(1L, false) } returns BaseResult.Success(Unit)
         viewModel.setFeedId(1L)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When
         viewModel.toggleFeedLike()
-        advanceTimeBy(1100)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        coVerify { likeFeedUseCase(1L, true) }
+        assertThat(viewModel.feed.value?.feedIsLiked).isFalse()
+        assertThat(viewModel.feed.value?.feedLikesCount).isEqualTo(9)
     }
 
     @Test
-    fun `refreshFeed - 피드와 댓글을 다시 로드한다`() = runTest {
+    fun `toggleCommentLike - 댓글 좋아요 토글 성공`() = runTest {
         // Given
         coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
-        coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(emptyList())
+        coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(listOf(sampleComment))
+        coEvery { likeCommentUseCase(1L, true) } returns BaseResult.Success(Unit)
         viewModel.setFeedId(1L)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When
-        viewModel.refreshFeed()
+        val commentItem = CommentItem.CommentData(sampleComment)
+        viewModel.toggleCommentLike(commentItem)
+        testDispatcher.scheduler.advanceTimeBy(LIKE_DEBOUNCE_MS_FOR_TEST)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        coVerify(atLeast = 2) { getFeedDetailUseCase(1L) }
-        coVerify(atLeast = 2) { getCommentsUseCase(1L) }
+        coVerify { likeCommentUseCase(1L, true) }
+    }
+
+    @Test
+    fun `toggleCommentLike - 좋아요 실패 시 상태를 롤백한다`() = runTest {
+        // Given
+        coEvery { getMemberIdUseCase() } returns "member1"
+        coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
+        coEvery { getCommentsUseCase(1L) } returns BaseResult.Success(listOf(sampleComment))
+        coEvery { likeCommentUseCase(1L, true) } returns BaseResult.Error("ERROR", "Failed")
+        viewModel.setFeedId(1L)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        val commentItem = CommentItem.CommentData(sampleComment)
+        viewModel.toggleCommentLike(commentItem)
+        testDispatcher.scheduler.advanceTimeBy(LIKE_DEBOUNCE_MS_FOR_TEST)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        val comment = viewModel.comments.value?.find { it.commentId == 1L }
+        assertThat(comment?.isLiked).isFalse()
+    }
+
+    companion object {
+        private const val LIKE_DEBOUNCE_MS_FOR_TEST = 1100L
     }
 }

--- a/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedFormViewModelTest.kt
+++ b/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedFormViewModelTest.kt
@@ -5,8 +5,9 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.project200.domain.model.BaseResult
-import com.project200.domain.model.CreateFeedResult
 import com.project200.domain.model.Feed
+import com.project200.domain.model.FeedCreateResult
+import com.project200.domain.model.FeedPicture
 import com.project200.domain.model.PreferredExercise
 import com.project200.domain.model.UserProfile
 import com.project200.domain.usecase.CreateFeedUseCase
@@ -34,6 +35,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDateTime
 
 @ExperimentalCoroutinesApi
 class FeedFormViewModelTest {
@@ -72,12 +74,16 @@ class FeedFormViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private val sampleProfile = UserProfile(
-        memberId = "member1",
+        profileThumbnailUrl = null,
+        profileImageUrl = null,
         nickname = "테스터",
         gender = "MALE",
         birthDate = "1990-01-01",
-        memberScore = 80,
-        thumbnailUrl = null
+        bio = null,
+        yearlyExerciseDays = 100,
+        exerciseCountInLast30Days = 15,
+        exerciseScore = 80,
+        preferredExercises = emptyList()
     )
 
     private val sampleExercise = PreferredExercise(
@@ -95,13 +101,16 @@ class FeedFormViewModelTest {
         nickname = "테스터",
         feedTypeName = "헬스",
         feedTypeId = 1L,
+        feedTypeDesc = "헬스 운동",
         feedContent = "기존 내용",
         feedPictures = emptyList(),
         feedLikesCount = 0,
         feedCommentsCount = 0,
         feedIsLiked = false,
-        createdAt = "2025-01-01T10:00:00",
-        thumbnailUrl = null
+        feedCreatedAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
+        feedHasCommented = false,
+        thumbnailUrl = null,
+        profileUrl = null
     )
 
     @Before
@@ -129,7 +138,7 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
 
         // When
         viewModel.initData()
@@ -144,7 +153,7 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
 
         // When
@@ -156,41 +165,42 @@ class FeedFormViewModelTest {
     }
 
     @Test
-    fun `initData - 사용자 프로필을 로드한다`() = runTest {
+    fun `initData - 수정 모드에서 기존 내용을 로드한다`() = runTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
+        coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
+        coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
+
+        // When
+        viewModel.initData(feedId = 1L)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertThat(viewModel.initialContentForEdit.value).isEqualTo("기존 내용")
+    }
+
+    @Test
+    fun `initData - 프로필 로드 실패 시 토스트 이벤트 발생`() = runTest {
+        // Given
+        coEvery { getUserProfileUseCase() } returns BaseResult.Error("ERROR", "Failed")
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
 
-        // When
-        viewModel.initData()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Then
-        assertThat(viewModel.userProfile.value).isEqualTo(sampleProfile)
+        // When & Then
+        viewModel.toastEvent.test {
+            viewModel.initData()
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertThat(awaitItem()).isNotNull()
+        }
     }
 
     @Test
-    fun `initData - 운동 타입을 로드한다`() = runTest {
+    fun `selectType - 운동 타입을 선택할 수 있다`() = runTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
-
-        // When
-        viewModel.initData()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Then
-        assertThat(viewModel.exerciseTypes.value).hasSize(1)
-    }
-
-    @Test
-    fun `selectType - 운동 타입을 선택한다`() = runTest {
-        // Given
-        coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
-        coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         viewModel.initData()
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -202,25 +212,27 @@ class FeedFormViewModelTest {
     }
 
     @Test
-    fun `addImages - 이미지를 추가한다`() {
+    fun `addImages - 이미지를 추가할 수 있다`() = runTest {
         // Given
-        val uri = mockk<Uri>()
+        val mockUri = mockk<Uri>()
+        every { mockUri.toString() } returns "content://image/1"
 
         // When
-        viewModel.addImages(listOf(uri))
+        viewModel.addImages(listOf(mockUri))
 
         // Then
         assertThat(viewModel.selectedImages.value).hasSize(1)
     }
 
     @Test
-    fun `removeImage - 이미지를 제거한다`() {
+    fun `removeImage - 이미지를 삭제할 수 있다`() = runTest {
         // Given
-        val uri = mockk<Uri>()
-        viewModel.addImages(listOf(uri))
+        val mockUri = mockk<Uri>()
+        every { mockUri.toString() } returns "content://image/1"
+        viewModel.addImages(listOf(mockUri))
 
         // When
-        viewModel.removeImage(uri)
+        viewModel.removeImage(mockUri)
 
         // Then
         assertThat(viewModel.selectedImages.value).isEmpty()
@@ -241,8 +253,8 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { createFeedUseCase(any()) } returns BaseResult.Success(CreateFeedResult(feedId = 1L))
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
+        coEvery { createFeedUseCase(any()) } returns BaseResult.Success(FeedCreateResult(feedId = 1L))
         viewModel.initData()
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -260,9 +272,9 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { createFeedUseCase(any()) } returns BaseResult.Success(CreateFeedResult(feedId = 1L))
-        coEvery { uploadFeedImagesUseCase(1L, any()) } returns BaseResult.Success(Unit)
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
+        coEvery { createFeedUseCase(any()) } returns BaseResult.Success(FeedCreateResult(feedId = 1L))
+        coEvery { uploadFeedImagesUseCase(1L, any()) } returns BaseResult.Success(listOf(FeedPicture(1L, "url")))
 
         val mockUri = mockk<Uri>()
         every { mockUri.toString() } returns "content://image/1"
@@ -283,7 +295,7 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         coEvery { getFeedDetailUseCase(1L) } returns BaseResult.Success(sampleFeed)
         coEvery { updateFeedUseCase(any()) } returns BaseResult.Success(Unit)
         viewModel.initData(feedId = 1L)
@@ -303,7 +315,7 @@ class FeedFormViewModelTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         coEvery { createFeedUseCase(any()) } returns BaseResult.Error("ERROR", "Failed")
         viewModel.initData()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -317,11 +329,11 @@ class FeedFormViewModelTest {
     }
 
     @Test
-    fun `requestShowDabangSelection - 운동 타입이 있으면 바텀시트를 표시한다`() = runTest {
+    fun `requestShowDabangSelection - 운동 타입 목록이 있으면 바텀시트를 표시한다`() = runTest {
         // Given
         coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         viewModel.initData()
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -330,22 +342,5 @@ class FeedFormViewModelTest {
 
         // Then
         assertThat(viewModel.showDabangSelection.value).isNotNull()
-    }
-
-    @Test
-    fun `onDabangSelectionShown - 바텀시트 상태를 초기화한다`() = runTest {
-        // Given
-        coEvery { getUserProfileUseCase() } returns BaseResult.Success(sampleProfile)
-        coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(sampleExercise))
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
-        viewModel.initData()
-        testDispatcher.scheduler.advanceUntilIdle()
-        viewModel.requestShowDabangSelection()
-
-        // When
-        viewModel.onDabangSelectionShown()
-
-        // Then
-        assertThat(viewModel.showDabangSelection.value).isNull()
     }
 }

--- a/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedListViewModelTest.kt
+++ b/feature/feed/src/test/java/com/project200/undabang/feature/feed/FeedListViewModelTest.kt
@@ -4,9 +4,11 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.project200.domain.model.BaseResult
+import com.project200.domain.model.ExerciseType
 import com.project200.domain.model.Feed
-import com.project200.domain.model.FeedList
+import com.project200.domain.model.FeedListResult
 import com.project200.domain.model.PreferredExercise
+import java.time.LocalDateTime
 import com.project200.domain.usecase.DeleteFeedUseCase
 import com.project200.domain.usecase.GetFeedsUseCase
 import com.project200.domain.usecase.GetMemberIdUseCase
@@ -55,22 +57,31 @@ class FeedListViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
+    private val sampleExerciseType = ExerciseType(
+        id = 1L,
+        name = "헬스",
+        imageUrl = null
+    )
+
     private val sampleFeed = Feed(
         feedId = 1L,
         memberId = "member1",
         nickname = "테스터",
         feedTypeName = "헬스",
         feedTypeId = 1L,
+        feedTypeDesc = "헬스 운동",
         feedContent = "테스트 피드",
         feedPictures = emptyList(),
         feedLikesCount = 0,
         feedCommentsCount = 0,
         feedIsLiked = false,
-        createdAt = "2025-01-01T10:00:00",
-        thumbnailUrl = null
+        feedCreatedAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
+        feedHasCommented = false,
+        thumbnailUrl = null,
+        profileUrl = null
     )
 
-    private val sampleFeedList = FeedList(
+    private val sampleFeedListResult = FeedListResult(
         feeds = listOf(sampleFeed),
         hasNext = false
     )
@@ -95,7 +106,7 @@ class FeedListViewModelTest {
     }
 
     private fun createViewModel(): FeedListViewModel {
-        coEvery { getFeedsUseCase(any(), any()) } returns BaseResult.Success(sampleFeedList)
+        coEvery { getFeedsUseCase(any(), any()) } returns BaseResult.Success(sampleFeedListResult)
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
         coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
         coEvery { getMemberIdUseCase() } returns "member1"
@@ -150,10 +161,39 @@ class FeedListViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When
-        viewModel.selectType("헬스")
+        viewModel.selectType(sampleExerciseType)
 
         // Then
-        assertThat(viewModel.selectedType.value).isEqualTo("헬스")
+        assertThat(viewModel.selectedType.value).isEqualTo(sampleExerciseType)
+    }
+
+    @Test
+    fun `selectType - feedTypeId로 필터링하여 목록을 반환한다`() = runTest {
+        // Given
+        val feed1 = sampleFeed.copy(feedId = 1L, feedTypeId = 1L)
+        val feed2 = sampleFeed.copy(feedId = 2L, feedTypeId = 2L)
+        coEvery { getFeedsUseCase(any(), any()) } returns BaseResult.Success(
+            FeedListResult(feeds = listOf(feed1, feed2), hasNext = false)
+        )
+        coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
+        coEvery { getMemberIdUseCase() } returns "member1"
+
+        viewModel = FeedListViewModel(
+            getFeedsUseCase,
+            getPreferredExerciseUseCase,
+            getPreferredExerciseTypesUseCase,
+            getMemberIdUseCase,
+            deleteFeedUseCase
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        viewModel.selectType(sampleExerciseType)
+
+        // Then
+        assertThat(viewModel.feedList.value).hasSize(1)
+        assertThat(viewModel.feedList.value?.first()?.feedTypeId).isEqualTo(1L)
     }
 
     @Test
@@ -161,7 +201,7 @@ class FeedListViewModelTest {
         // Given
         viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
-        viewModel.selectType("헬스")
+        viewModel.selectType(sampleExerciseType)
 
         // When
         viewModel.clearType()
@@ -173,10 +213,19 @@ class FeedListViewModelTest {
     @Test
     fun `canLoadMore - 로딩 중이 아니고 다음 페이지가 있으면 true`() = runTest {
         // Given
+        coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(listOf(samplePreferredExercise))
+        coEvery { getMemberIdUseCase() } returns "member1"
         coEvery { getFeedsUseCase(any(), any()) } returns BaseResult.Success(
-            FeedList(feeds = listOf(sampleFeed), hasNext = true)
+            FeedListResult(feeds = listOf(sampleFeed), hasNext = true)
         )
-        viewModel = createViewModel()
+        viewModel = FeedListViewModel(
+            getFeedsUseCase,
+            getPreferredExerciseUseCase,
+            getPreferredExerciseTypesUseCase,
+            getMemberIdUseCase,
+            deleteFeedUseCase
+        )
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When & Then
@@ -190,7 +239,7 @@ class FeedListViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When
-        viewModel.selectType("헬스")
+        viewModel.selectType(sampleExerciseType)
 
         // Then
         assertThat(viewModel.canLoadMore()).isFalse()
@@ -215,7 +264,7 @@ class FeedListViewModelTest {
         // Given
         coEvery { getFeedsUseCase(any(), any()) } returns BaseResult.Error("ERROR", "Failed")
         coEvery { getPreferredExerciseUseCase() } returns BaseResult.Success(emptyList())
-        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList())
+        coEvery { getPreferredExerciseTypesUseCase() } returns BaseResult.Success(emptyList<PreferredExercise>())
         coEvery { getMemberIdUseCase() } returns "member1"
 
         // When


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#486 
피드 목록에서 다방(운동 종류)을 선택해도 필터링이 되지 않고 목록이 비어있는 문제

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

원인
- feedTypeName(String)으로 필터링 → 문자열 불일치로 필터링 실패
- 운동 타입을 List<String>으로 관리하여 ID 기반 비교 불가

✅ 해결
- selectedType: String? → ExerciseType?
- exerciseTypeList: List<String> → List<ExerciseType>
- 필터링: feedTypeName 비교 → feedTypeId 비교

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?