### PR TITLE
[Refactor] Scaffold 공통 + 스크롤 #530

### DIFF
--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/PermissionScreen.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/PermissionScreen.kt
@@ -2,16 +2,16 @@ package com.project200.undabang.auth.register
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,9 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.project200.presentation.compose.components.button.PrimaryButton
+import com.project200.presentation.compose.components.layout.UndabangScaffold
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorGray200
-import com.project200.presentation.compose.theme.ColorWhite300
 import com.project200.presentation.compose.theme.contentBold
 import com.project200.presentation.compose.theme.header
 import com.project200.presentation.compose.theme.subtext12
@@ -36,53 +36,58 @@ fun PermissionScreen(
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300)
-                .padding(horizontal = 20.dp),
-    ) {
-        Spacer(Modifier.height(114.dp))
+    UndabangScaffold(
+        modifier = modifier,
+        bottomBar = {
+            PrimaryButton(
+                text = stringResource(PresentationR.string.confirm),
+                onClick = onNextClick,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 32.dp),
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .padding(horizontal = 20.dp)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(Modifier.height(114.dp))
 
-        Text(
-            text = stringResource(R.string.permission_title),
-            style = MaterialTheme.typography.header,
-        )
+            Text(
+                text = stringResource(R.string.permission_title),
+                style = MaterialTheme.typography.header,
+            )
 
-        Spacer(Modifier.height(77.dp))
+            Spacer(Modifier.height(77.dp))
 
-        PermissionRow(
-            iconRes = R.drawable.ic_permission_location,
-            title = stringResource(R.string.location_title),
-            desc = stringResource(R.string.location_desc),
-        )
+            PermissionRow(
+                iconRes = R.drawable.ic_permission_location,
+                title = stringResource(R.string.location_title),
+                desc = stringResource(R.string.location_desc),
+            )
 
-        Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
-        PermissionRow(
-            iconRes = R.drawable.ic_permission_notify,
-            title = stringResource(R.string.notify_title),
-            desc = stringResource(R.string.notify_desc),
-        )
+            PermissionRow(
+                iconRes = R.drawable.ic_permission_notify,
+                title = stringResource(R.string.notify_title),
+                desc = stringResource(R.string.notify_desc),
+            )
 
-        Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(24.dp))
 
-        PermissionRow(
-            iconRes = R.drawable.ic_permission_gallery,
-            title = stringResource(R.string.gallery_title),
-            desc = stringResource(R.string.gallery_desc),
-        )
-
-        Spacer(Modifier.weight(1f))
-
-        PrimaryButton(
-            text = stringResource(PresentationR.string.confirm),
-            onClick = onNextClick,
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        Spacer(Modifier.height(32.dp))
+            PermissionRow(
+                iconRes = R.drawable.ic_permission_gallery,
+                title = stringResource(R.string.gallery_title),
+                desc = stringResource(R.string.gallery_desc),
+            )
+        }
     }
 }
 

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/TermsScreen.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/TermsScreen.kt
@@ -1,16 +1,16 @@
 package com.project200.undabang.auth.register
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -27,9 +27,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.project200.presentation.compose.components.button.PrimaryButton
+import com.project200.presentation.compose.components.layout.UndabangScaffold
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorGray100
-import com.project200.presentation.compose.theme.ColorWhite300
 import com.project200.presentation.compose.theme.header
 import com.project200.presentation.compose.theme.subtext14
 import com.project200.undabang.feature.auth.R
@@ -47,48 +47,48 @@ fun TermsScreen(
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300)
-                .padding(horizontal = 20.dp),
-    ) {
-        Spacer(Modifier.height(114.dp))
+    UndabangScaffold(
+        modifier = modifier,
+        bottomBar = {
+            Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                TermsRow(
+                    title = stringResource(R.string.terms_required_service),
+                    checked = serviceChecked,
+                    onTitleClick = onServiceClick,
+                    onToggle = onToggleService,
+                )
+                Spacer(Modifier.height(16.dp))
+                TermsRow(
+                    title = stringResource(R.string.terms_required_privacy),
+                    checked = privacyChecked,
+                    onTitleClick = onPrivacyClick,
+                    onToggle = onTogglePrivacy,
+                )
+                Spacer(Modifier.height(77.dp))
+                PrimaryButton(
+                    text = stringResource(PresentationR.string.confirm),
+                    onClick = onNextClick,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = isAllRequiredChecked,
+                )
+                Spacer(Modifier.height(32.dp))
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .padding(horizontal = 20.dp)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(Modifier.height(114.dp))
 
-        Text(
-            text = stringResource(R.string.terms_title),
-            style = MaterialTheme.typography.header,
-        )
-
-        Spacer(Modifier.weight(1f))
-
-        TermsRow(
-            title = stringResource(R.string.terms_required_service),
-            checked = serviceChecked,
-            onTitleClick = onServiceClick,
-            onToggle = onToggleService,
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        TermsRow(
-            title = stringResource(R.string.terms_required_privacy),
-            checked = privacyChecked,
-            onTitleClick = onPrivacyClick,
-            onToggle = onTogglePrivacy,
-        )
-
-        Spacer(Modifier.height(77.dp))
-
-        PrimaryButton(
-            text = stringResource(PresentationR.string.confirm),
-            onClick = onNextClick,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = isAllRequiredChecked,
-        )
-
-        Spacer(Modifier.height(32.dp))
+            Text(
+                text = stringResource(R.string.terms_title),
+                style = MaterialTheme.typography.header,
+            )
+        }
     }
 }
 

--- a/feature/matching/src/main/java/com/project200/feature/matching/map/MatchingGuideScreen.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/map/MatchingGuideScreen.kt
@@ -9,13 +9,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,12 +31,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.project200.presentation.compose.components.button.PrimaryButton
+import com.project200.presentation.compose.components.layout.UndabangScaffold
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorBackground
 import com.project200.presentation.compose.theme.ColorBlack
 import com.project200.presentation.compose.theme.ColorGray100
 import com.project200.presentation.compose.theme.ColorGray200
-import com.project200.presentation.compose.theme.ColorWhite300
 import com.project200.presentation.compose.theme.contentBold
 import com.project200.presentation.compose.theme.contentRegular
 import com.project200.presentation.compose.theme.header
@@ -48,71 +49,72 @@ fun MatchingGuideScreen(
     onStartClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300),
-    ) {
-        Toolbar(onSkipClick = onSkipClick)
-
-        Spacer(Modifier.height(10.dp))
-
-        Box(
-            modifier =
-                Modifier
-                    .size(150.dp)
-                    .align(Alignment.CenterHorizontally)
-                    .clip(RoundedCornerShape(20.dp))
-                    .background(ColorBackground)
-                    .padding(10.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Image(
-                painter = painterResource(R.drawable.ic_guide_character),
-                contentDescription = null,
+    UndabangScaffold(
+        modifier = modifier,
+        topBar = { Toolbar(onSkipClick = onSkipClick) },
+        bottomBar = {
+            PrimaryButton(
+                text = stringResource(R.string.guide_start),
+                onClick = onStartClick,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 40.dp),
             )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(Modifier.height(10.dp))
+
+            Box(
+                modifier =
+                    Modifier
+                        .size(150.dp)
+                        .align(Alignment.CenterHorizontally)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(ColorBackground)
+                        .padding(10.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.ic_guide_character),
+                    contentDescription = null,
+                )
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(R.string.guide_title),
+                style = MaterialTheme.typography.header,
+                color = ColorBlack,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            Text(
+                text = stringResource(R.string.guide_content),
+                style = MaterialTheme.typography.mediumBold,
+                color = ColorGray100,
+                textAlign = TextAlign.Center,
+                fontSize = 15.sp,
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 20.dp),
+            )
+
+            Spacer(Modifier.height(30.dp))
+
+            GuideBeforeBox()
         }
-
-        Spacer(Modifier.height(20.dp))
-
-        Text(
-            text = stringResource(R.string.guide_title),
-            style = MaterialTheme.typography.header,
-            color = ColorBlack,
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        )
-
-        Spacer(Modifier.height(10.dp))
-
-        Text(
-            text = stringResource(R.string.guide_content),
-            style = MaterialTheme.typography.mediumBold,
-            color = ColorGray100,
-            textAlign = TextAlign.Center,
-            fontSize = 15.sp,
-            modifier =
-                Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(horizontal = 20.dp),
-        )
-
-        Spacer(Modifier.height(30.dp))
-
-        GuideBeforeBox()
-
-        Spacer(Modifier.weight(1f))
-
-        PrimaryButton(
-            text = stringResource(R.string.guide_start),
-            onClick = onStartClick,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-        )
-
-        Spacer(Modifier.height(40.dp))
     }
 }
 

--- a/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceRegisterScreen.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceRegisterScreen.kt
@@ -1,16 +1,16 @@
 package com.project200.feature.matching.place
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,11 +28,11 @@ import androidx.compose.ui.unit.sp
 import com.project200.presentation.compose.components.button.PrimaryButton
 import com.project200.presentation.compose.components.input.TextFieldVariant
 import com.project200.presentation.compose.components.input.UndabangTextField
+import com.project200.presentation.compose.components.layout.UndabangScaffold
 import com.project200.presentation.compose.components.layout.UndabangTopBar
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorBlack
 import com.project200.presentation.compose.theme.ColorGray200
-import com.project200.presentation.compose.theme.ColorWhite300
 import com.project200.presentation.compose.theme.contentBold
 import com.project200.presentation.compose.theme.contentRegular
 import com.project200.undabang.feature.matching.R
@@ -47,61 +47,64 @@ fun ExercisePlaceRegisterScreen(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300),
-    ) {
-        UndabangTopBar(
-            title = stringResource(R.string.exercise_place_register_title),
-            onNavigationClick = onBackClick,
-        )
-
-        PlaceInfoSection(
-            placeName = placeName,
-            placeAddress = placeAddress,
-        )
-
-        Spacer(Modifier.height(30.dp))
-
-        Text(
-            text = stringResource(R.string.place_name_title),
-            style = MaterialTheme.typography.contentBold,
-            color = ColorBlack,
-            modifier = Modifier.padding(horizontal = 20.dp),
-        )
-
-        Spacer(Modifier.height(4.dp))
-
-        UndabangTextField(
-            value = placeNameInput,
-            onValueChange = onPlaceNameChange,
-            hint = stringResource(R.string.place_name_hint),
-            variant = TextFieldVariant.Outlined,
+    UndabangScaffold(
+        modifier = modifier,
+        topBar = {
+            UndabangTopBar(
+                title = stringResource(R.string.exercise_place_register_title),
+                onNavigationClick = onBackClick,
+            )
+        },
+        bottomBar = {
+            PrimaryButton(
+                text = stringResource(R.string.exercise_place_register_complete),
+                onClick = onRegisterClick,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 40.dp),
+            )
+        },
+    ) { innerPadding ->
+        Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .height(50.dp),
-        )
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            PlaceInfoSection(
+                placeName = placeName,
+                placeAddress = placeAddress,
+            )
 
-        Spacer(Modifier.height(30.dp))
+            Spacer(Modifier.height(30.dp))
 
-        NoticeSection()
+            Text(
+                text = stringResource(R.string.place_name_title),
+                style = MaterialTheme.typography.contentBold,
+                color = ColorBlack,
+                modifier = Modifier.padding(horizontal = 20.dp),
+            )
 
-        Spacer(Modifier.weight(1f))
+            Spacer(Modifier.height(4.dp))
 
-        PrimaryButton(
-            text = stringResource(R.string.exercise_place_register_complete),
-            onClick = onRegisterClick,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-        )
+            UndabangTextField(
+                value = placeNameInput,
+                onValueChange = onPlaceNameChange,
+                hint = stringResource(R.string.place_name_hint),
+                variant = TextFieldVariant.Outlined,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .height(50.dp),
+            )
 
-        Spacer(Modifier.height(40.dp))
+            Spacer(Modifier.height(30.dp))
+
+            NoticeSection()
+        }
     }
 }
 

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/NotificationScreen.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/NotificationScreen.kt
@@ -1,13 +1,13 @@
 package com.project200.undabang.profile.setting
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.project200.presentation.compose.components.layout.UndabangScaffold
 import com.project200.presentation.compose.components.layout.UndabangTopBar
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorBlack
@@ -37,27 +38,32 @@ fun NotificationScreen(
     onChattingToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300),
-    ) {
-        UndabangTopBar(
-            title = stringResource(R.string.notification),
-            onNavigationClick = onNavigateBack,
-        )
-
-        NotificationSwitchRow(
-            labelRes = R.string.exercise_notification,
-            checked = isExerciseOn,
-            onCheckedChange = onExerciseToggle,
-        )
-        NotificationSwitchRow(
-            labelRes = R.string.chatting_notification,
-            checked = isChattingOn,
-            onCheckedChange = onChattingToggle,
-        )
+    UndabangScaffold(
+        modifier = modifier,
+        topBar = {
+            UndabangTopBar(
+                title = stringResource(R.string.notification),
+                onNavigationClick = onNavigateBack,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            NotificationSwitchRow(
+                labelRes = R.string.exercise_notification,
+                checked = isExerciseOn,
+                onCheckedChange = onExerciseToggle,
+            )
+            NotificationSwitchRow(
+                labelRes = R.string.chatting_notification,
+                checked = isChattingOn,
+                onCheckedChange = onChattingToggle,
+            )
+        }
     }
 }
 

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingScreen.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingScreen.kt
@@ -9,13 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -31,6 +32,14 @@ import com.project200.presentation.compose.theme.contentRegular
 import com.project200.undabang.feature.profile.R
 import com.project200.undabang.presentation.R as PresentationR
 
+private data class SettingMenuItemData(
+    @DrawableRes val iconRes: Int,
+    @StringRes val labelRes: Int,
+    val onClick: (() -> Unit)? = null,
+    val trailingText: String? = null,
+    val showDivider: Boolean = true,
+)
+
 @Composable
 fun SettingScreen(
     versionName: String,
@@ -44,6 +53,54 @@ fun SettingScreen(
     onNotificationClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // 메뉴 항목을 데이터로 묶어 반복 코드 정리
+    val items =
+        remember(versionName) {
+            listOf(
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_customer_service,
+                    labelRes = R.string.customer_service,
+                    onClick = onCustomerServiceClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_logout,
+                    labelRes = R.string.logout,
+                    onClick = onLogoutClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_withdraw,
+                    labelRes = R.string.withdraw,
+                    onClick = onWithdrawClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_block,
+                    labelRes = R.string.block_members,
+                    onClick = onBlockMembersClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_document,
+                    labelRes = R.string.terms,
+                    onClick = onTermsClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_document,
+                    labelRes = R.string.privacy,
+                    onClick = onPrivacyClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = R.drawable.ic_notification,
+                    labelRes = R.string.notification,
+                    onClick = onNotificationClick,
+                ),
+                SettingMenuItemData(
+                    iconRes = PresentationR.drawable.ic_version_info,
+                    labelRes = R.string.version_info,
+                    trailingText = versionName,
+                    showDivider = false,
+                ),
+            )
+        }
+
     UndabangScaffold(
         modifier = modifier,
         topBar = {
@@ -53,72 +110,25 @@ fun SettingScreen(
             )
         },
     ) { innerPadding ->
-        Column(
-            modifier =
-                Modifier
-                    .padding(innerPadding)
-                    .verticalScroll(rememberScrollState()),
-        ) {
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_customer_service,
-                labelRes = R.string.customer_service,
-                onClick = onCustomerServiceClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_logout,
-                labelRes = R.string.logout,
-                onClick = onLogoutClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_withdraw,
-                labelRes = R.string.withdraw,
-                onClick = onWithdrawClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_block,
-                labelRes = R.string.block_members,
-                onClick = onBlockMembersClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_document,
-                labelRes = R.string.terms,
-                onClick = onTermsClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_document,
-                labelRes = R.string.privacy,
-                onClick = onPrivacyClick,
-            )
-            SettingMenuItem(
-                iconRes = R.drawable.ic_notification,
-                labelRes = R.string.notification,
-                onClick = onNotificationClick,
-            )
-            SettingMenuItem(
-                iconRes = PresentationR.drawable.ic_version_info,
-                labelRes = R.string.version_info,
-                trailingText = versionName,
-                showDivider = false,
-            )
+        LazyColumn(modifier = Modifier.padding(innerPadding)) {
+            items(items, key = { it.labelRes }) { item ->
+                SettingMenuItem(item = item)
+            }
         }
     }
 }
 
 @Composable
 private fun SettingMenuItem(
-    @DrawableRes iconRes: Int,
-    @StringRes labelRes: Int,
+    item: SettingMenuItemData,
     modifier: Modifier = Modifier,
-    trailingText: String? = null,
-    showDivider: Boolean = true,
-    onClick: (() -> Unit)? = null,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         Row(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+                    .let { if (item.onClick != null) it.clickable(onClick = item.onClick) else it }
                     .padding(horizontal = 20.dp, vertical = 19.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -128,27 +138,27 @@ private fun SettingMenuItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    painter = painterResource(id = iconRes),
+                    painter = painterResource(id = item.iconRes),
                     contentDescription = null,
                     tint = ColorBlack,
                     modifier = Modifier.size(24.dp),
                 )
                 Text(
-                    text = stringResource(id = labelRes),
+                    text = stringResource(id = item.labelRes),
                     modifier = Modifier.padding(start = 8.dp),
                     style = MaterialTheme.typography.contentRegular,
                     color = ColorBlack,
                 )
             }
-            if (trailingText != null) {
+            if (item.trailingText != null) {
                 Text(
-                    text = trailingText,
+                    text = item.trailingText,
                     style = MaterialTheme.typography.contentRegular,
                     color = ColorGray200,
                 )
             }
         }
-        if (showDivider) {
+        if (item.showDivider) {
             HorizontalDivider(thickness = 0.3.dp, color = ColorBlack)
         }
     }

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingScreen.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingScreen.kt
@@ -2,15 +2,15 @@ package com.project200.undabang.profile.setting
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,10 +22,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.project200.presentation.compose.components.layout.UndabangScaffold
+import com.project200.presentation.compose.components.layout.UndabangTopBar
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorBlack
 import com.project200.presentation.compose.theme.ColorGray200
-import com.project200.presentation.compose.theme.ColorWhite300
 import com.project200.presentation.compose.theme.contentRegular
 import com.project200.undabang.feature.profile.R
 import com.project200.undabang.presentation.R as PresentationR
@@ -43,58 +44,63 @@ fun SettingScreen(
     onNotificationClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(ColorWhite300),
-    ) {
-        com.project200.presentation.compose.components.layout.UndabangTopBar(
-            title = stringResource(R.string.setting),
-            onNavigationClick = onNavigateBack,
-        )
-
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_customer_service,
-            labelRes = R.string.customer_service,
-            onClick = onCustomerServiceClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_logout,
-            labelRes = R.string.logout,
-            onClick = onLogoutClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_withdraw,
-            labelRes = R.string.withdraw,
-            onClick = onWithdrawClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_block,
-            labelRes = R.string.block_members,
-            onClick = onBlockMembersClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_document,
-            labelRes = R.string.terms,
-            onClick = onTermsClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_document,
-            labelRes = R.string.privacy,
-            onClick = onPrivacyClick,
-        )
-        SettingMenuItem(
-            iconRes = R.drawable.ic_notification,
-            labelRes = R.string.notification,
-            onClick = onNotificationClick,
-        )
-        SettingMenuItem(
-            iconRes = PresentationR.drawable.ic_version_info,
-            labelRes = R.string.version_info,
-            trailingText = versionName,
-            showDivider = false,
-        )
+    UndabangScaffold(
+        modifier = modifier,
+        topBar = {
+            UndabangTopBar(
+                title = stringResource(R.string.setting),
+                onNavigationClick = onNavigateBack,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_customer_service,
+                labelRes = R.string.customer_service,
+                onClick = onCustomerServiceClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_logout,
+                labelRes = R.string.logout,
+                onClick = onLogoutClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_withdraw,
+                labelRes = R.string.withdraw,
+                onClick = onWithdrawClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_block,
+                labelRes = R.string.block_members,
+                onClick = onBlockMembersClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_document,
+                labelRes = R.string.terms,
+                onClick = onTermsClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_document,
+                labelRes = R.string.privacy,
+                onClick = onPrivacyClick,
+            )
+            SettingMenuItem(
+                iconRes = R.drawable.ic_notification,
+                labelRes = R.string.notification,
+                onClick = onNotificationClick,
+            )
+            SettingMenuItem(
+                iconRes = PresentationR.drawable.ic_version_info,
+                labelRes = R.string.version_info,
+                trailingText = versionName,
+                showDivider = false,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/project200/presentation/compose/components/layout/Scaffold.kt
+++ b/presentation/src/main/java/com/project200/presentation/compose/components/layout/Scaffold.kt
@@ -1,0 +1,33 @@
+package com.project200.presentation.compose.components.layout
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.project200.presentation.compose.theme.ColorWhite300
+
+/**
+ * 앱 공통 화면 골격
+ * Material3 Scaffold를 감싸 containerColor 기본값(ColorWhite300)을 지정한다
+ * 본문 스크롤은 호출부에서 Column + verticalScroll 또는 LazyColumn으로 선택
+ *
+ * 키보드/시스템 바 인셋은 Scaffold가 자동으로 분배하므로
+ * bottomBar에 둔 버튼은 키보드가 올라올 때 함께 밀린다
+ */
+@Composable
+fun UndabangScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    containerColor: Color = ColorWhite300,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        containerColor = containerColor,
+        content = content,
+    )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#530

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

공통 화면 골격 컴포넌트를 도입하고, 스크롤 누락 6개 화면에 적용했습니다

- UndabangScaffold 신규 (`presentation/.../components/layout/Scaffold.kt`)
  - Material3 Scaffold 기반, containerColor 기본값 ColorWhite300
  - topBar / bottomBar 슬롯 + 시스템 바·키보드 인셋 자동 분배
- 스크롤 누락 6개 화면에 적용
  - SettingScreen, NotificationScreen
    - Column에 verticalScroll 단순 추가
  - PermissionScreen, MatchingGuideScreen, ExercisePlaceRegisterScreen
    - 하단 PrimaryButton을 bottomBar 슬롯으로 이동
    - 본문 Column에 verticalScroll
  - TermsScreen
    - 약관 두 줄 + 확인 버튼을 bottomBar 슬롯으로 묶음 (작은 디바이스에서 약관·버튼이 잘리지 않게)
    - 본문은 타이틀만

기존 Compose 화면 전체를 Scaffold로 일괄 전환하는 작업은 후속 PR로 분리했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
