### PR TITLE
[Refactor] 공통 KakaoMapView 추출 + 장소 검색 Compose 전환 #551

### DIFF
--- a/feature/exercise/src/main/java/com/project200/feature/exercise/form/PlaceSearchFragment.kt
+++ b/feature/exercise/src/main/java/com/project200/feature/exercise/form/PlaceSearchFragment.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -13,19 +15,19 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.kakao.vectormap.GestureType
 import com.kakao.vectormap.KakaoMap
-import com.kakao.vectormap.KakaoMapReadyCallback
 import com.kakao.vectormap.LatLng
-import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import com.project200.common.constants.RuleConstants
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.KakaoPlaceInfo
 import com.project200.presentation.base.BindingFragment
+import com.project200.presentation.compose.applyAppTheme
+import com.project200.presentation.compose.map.KakaoMapView
 import com.project200.undabang.feature.exercise.R
 import com.project200.undabang.feature.exercise.databinding.FragmentPlaceSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class PlaceSearchFragment : BindingFragment<FragmentPlaceSearchBinding>(R.layout.fragment_place_search) {
@@ -98,30 +100,23 @@ class PlaceSearchFragment : BindingFragment<FragmentPlaceSearchBinding>(R.layout
         }
     }
 
-    // 지도 초기화 함수
+    // 지도 초기화 함수: 공통 KakaoMapView 컴포저블을 ComposeView에 호스팅 (생명주기는 컴포저블이 처리)
     private fun initMapView() {
-        binding.mapView.start(
-            object : MapLifeCycleCallback() {
-                override fun onMapDestroy() {}
-
-                override fun onMapError(error: Exception) {
-                    Timber.d("$error")
-                }
-            },
-            object : KakaoMapReadyCallback() {
-                override fun onMapReady(map: KakaoMap) {
+        binding.mapComposeView.applyAppTheme {
+            KakaoMapView(
+                modifier = Modifier.fillMaxSize(),
+                onMapReady = { map ->
                     kakaoMap = map
                     setupInitialMapPosition()
 
-                    // 두 손가락으로 지도를 회전시키는 제스처 비활성화
-                    kakaoMap?.setGestureEnable(com.kakao.vectormap.GestureType.Rotate, false)
-                    // 두 손가락으로 지도를 기울이는 제스처(틸트) 비활성화
-                    kakaoMap?.setGestureEnable(com.kakao.vectormap.GestureType.Tilt, false)
+                    // 두 손가락으로 지도를 회전/기울이는 제스처 비활성화
+                    map.setGestureEnable(GestureType.Rotate, false)
+                    map.setGestureEnable(GestureType.Tilt, false)
 
                     setMapListeners()
-                }
-            },
-        )
+                },
+            )
+        }
     }
 
     /**
@@ -153,8 +148,8 @@ class PlaceSearchFragment : BindingFragment<FragmentPlaceSearchBinding>(R.layout
         kakaoMap?.setOnCameraMoveEndListener { _, _, _ ->
             val map = kakaoMap ?: return@setOnCameraMoveEndListener
 
-            val targetScreenX = binding.mapView.width / 2
-            val targetScreenY = binding.centerMarkerIv.bottom - binding.mapView.top
+            val targetScreenX = binding.mapComposeView.width / 2
+            val targetScreenY = binding.centerMarkerIv.bottom - binding.mapComposeView.top
 
             val targetLatLng = map.fromScreenPoint(targetScreenX, targetScreenY)
 
@@ -214,8 +209,8 @@ class PlaceSearchFragment : BindingFragment<FragmentPlaceSearchBinding>(R.layout
                 // 검색 결과 아이템 클릭 시 동작
                 kakaoMap?.let { map ->
                     // 현재 화면을 기준으로, 지도 중앙과 마커 끝의 위도 값을 구합니다.
-                    val mapCenterLatLng = map.fromScreenPoint(binding.mapView.width / 2, binding.mapView.height / 2)
-                    val markerTipLatLng = map.fromScreenPoint(binding.mapView.width / 2, binding.centerMarkerIv.bottom)
+                    val mapCenterLatLng = map.fromScreenPoint(binding.mapComposeView.width / 2, binding.mapComposeView.height / 2)
+                    val markerTipLatLng = map.fromScreenPoint(binding.mapComposeView.width / 2, binding.centerMarkerIv.bottom)
 
                     // 두 위도 값의 차이를 계산하여 '보정값(offset)'을 구합니다. (null일 경우를 대비해 기본값 0.0 사용)
                     val latOffset = (mapCenterLatLng?.latitude ?: 0.0) - (markerTipLatLng?.latitude ?: 0.0)
@@ -271,16 +266,6 @@ class PlaceSearchFragment : BindingFragment<FragmentPlaceSearchBinding>(R.layout
             requireContext(),
             Manifest.permission.ACCESS_FINE_LOCATION,
         ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    override fun onResume() {
-        super.onResume()
-        binding.mapView.resume()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        binding.mapView.pause()
     }
 
     companion object {

--- a/feature/exercise/src/main/res/layout/fragment_place_search.xml
+++ b/feature/exercise/src/main/res/layout/fragment_place_search.xml
@@ -53,8 +53,8 @@
             app:layout_constraintEnd_toEndOf="@+id/base_toolbar"
             app:layout_constraintTop_toTopOf="@+id/base_toolbar" />
     </LinearLayout>
-    <com.kakao.vectormap.MapView
-        android:id="@+id/map_view"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/map_compose_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/search_toolbar_ll"
@@ -62,10 +62,10 @@
     <ImageView
         android:id="@+id/center_marker_iv"
         android:src="@drawable/ic_exercise_place_marker"
-        app:layout_constraintTop_toTopOf="@id/map_view"
+        app:layout_constraintTop_toTopOf="@id/map_compose_view"
         app:layout_constraintBottom_toTopOf="@id/place_address_cl"
-        app:layout_constraintEnd_toEndOf="@id/map_view"
-        app:layout_constraintStart_toStartOf="@id/map_view"
+        app:layout_constraintEnd_toEndOf="@id/map_compose_view"
+        app:layout_constraintStart_toStartOf="@id/map_compose_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:tint="@color/black" />

--- a/feature/matching/src/main/java/com/project200/feature/matching/map/compose/MatchingMapScreen.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/map/compose/MatchingMapScreen.kt
@@ -45,6 +45,7 @@ import com.project200.feature.matching.map.cluster.ClusterCalculator
 import com.project200.feature.matching.map.cluster.MapClusterItem
 import com.project200.feature.matching.utils.FilterState
 import com.project200.feature.matching.utils.MatchingFilterType
+import com.project200.presentation.compose.map.KakaoMapView
 import com.project200.presentation.compose.theme.AppTheme
 import com.project200.presentation.compose.theme.ColorBlack
 import com.project200.presentation.compose.theme.ColorGray200

--- a/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceSearchFragment.kt
+++ b/feature/matching/src/main/java/com/project200/feature/matching/place/ExercisePlaceSearchFragment.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -13,19 +15,19 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.kakao.vectormap.GestureType
 import com.kakao.vectormap.KakaoMap
-import com.kakao.vectormap.KakaoMapReadyCallback
 import com.kakao.vectormap.LatLng
-import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import com.project200.common.constants.RuleConstants
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.KakaoPlaceInfo
 import com.project200.presentation.base.BindingFragment
+import com.project200.presentation.compose.applyAppTheme
+import com.project200.presentation.compose.map.KakaoMapView
 import com.project200.undabang.feature.matching.R
 import com.project200.undabang.feature.matching.databinding.FragmentExercisePlaceSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class ExercisePlaceSearchFragment : BindingFragment<FragmentExercisePlaceSearchBinding>(R.layout.fragment_exercise_place_search) {
@@ -104,30 +106,23 @@ class ExercisePlaceSearchFragment : BindingFragment<FragmentExercisePlaceSearchB
         }
     }
 
-    // 지도 초기화 함수
+    // 지도 초기화 함수: 공통 KakaoMapView 컴포저블을 ComposeView에 호스팅 (생명주기는 컴포저블이 처리)
     private fun initMapView() {
-        binding.mapView.start(
-            object : MapLifeCycleCallback() {
-                override fun onMapDestroy() {}
-
-                override fun onMapError(error: Exception) {
-                    Timber.d("$error")
-                }
-            },
-            object : KakaoMapReadyCallback() {
-                override fun onMapReady(map: KakaoMap) {
+        binding.mapComposeView.applyAppTheme {
+            KakaoMapView(
+                modifier = Modifier.fillMaxSize(),
+                onMapReady = { map ->
                     kakaoMap = map
                     setupInitialMapPosition()
 
-                    // 두 손가락으로 지도를 회전시키는 제스처 비활성화
-                    kakaoMap?.setGestureEnable(com.kakao.vectormap.GestureType.Rotate, false)
-                    // 두 손가락으로 지도를 기울이는 제스처(틸트) 비활성화
-                    kakaoMap?.setGestureEnable(com.kakao.vectormap.GestureType.Tilt, false)
+                    // 두 손가락으로 지도를 회전/기울이는 제스처 비활성화
+                    map.setGestureEnable(GestureType.Rotate, false)
+                    map.setGestureEnable(GestureType.Tilt, false)
 
                     setMapListeners()
-                }
-            },
-        )
+                },
+            )
+        }
     }
 
     /**
@@ -159,8 +154,8 @@ class ExercisePlaceSearchFragment : BindingFragment<FragmentExercisePlaceSearchB
         kakaoMap?.setOnCameraMoveEndListener { _, _, _ ->
             val map = kakaoMap ?: return@setOnCameraMoveEndListener
 
-            val targetScreenX = binding.mapView.width / 2
-            val targetScreenY = binding.centerMarkerIv.bottom - binding.mapView.top
+            val targetScreenX = binding.mapComposeView.width / 2
+            val targetScreenY = binding.centerMarkerIv.bottom - binding.mapComposeView.top
 
             val targetLatLng = map.fromScreenPoint(targetScreenX, targetScreenY)
 
@@ -220,8 +215,8 @@ class ExercisePlaceSearchFragment : BindingFragment<FragmentExercisePlaceSearchB
                 // 검색 결과 아이템 클릭 시 동작
                 kakaoMap?.let { map ->
                     // 현재 화면을 기준으로, 지도 중앙과 마커 끝의 위도 값을 구합니다.
-                    val mapCenterLatLng = map.fromScreenPoint(binding.mapView.width / 2, binding.mapView.height / 2)
-                    val markerTipLatLng = map.fromScreenPoint(binding.mapView.width / 2, binding.centerMarkerIv.bottom)
+                    val mapCenterLatLng = map.fromScreenPoint(binding.mapComposeView.width / 2, binding.mapComposeView.height / 2)
+                    val markerTipLatLng = map.fromScreenPoint(binding.mapComposeView.width / 2, binding.centerMarkerIv.bottom)
 
                     // 두 위도 값의 차이를 계산하여 '보정값(offset)'을 구합니다. (null일 경우를 대비해 기본값 0.0 사용)
                     val latOffset = (mapCenterLatLng?.latitude ?: 0.0) - (markerTipLatLng?.latitude ?: 0.0)
@@ -277,16 +272,6 @@ class ExercisePlaceSearchFragment : BindingFragment<FragmentExercisePlaceSearchB
             requireContext(),
             Manifest.permission.ACCESS_FINE_LOCATION,
         ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    override fun onResume() {
-        super.onResume()
-        binding.mapView.resume()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        binding.mapView.pause()
     }
 
     companion object {

--- a/feature/matching/src/main/res/layout/fragment_exercise_place_search.xml
+++ b/feature/matching/src/main/res/layout/fragment_exercise_place_search.xml
@@ -53,8 +53,8 @@
             app:layout_constraintEnd_toEndOf="@+id/base_toolbar"
             app:layout_constraintTop_toTopOf="@+id/base_toolbar" />
     </LinearLayout>
-    <com.kakao.vectormap.MapView
-        android:id="@+id/map_view"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/map_compose_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@id/search_toolbar_ll"
@@ -62,10 +62,10 @@
     <ImageView
         android:id="@+id/center_marker_iv"
         android:src="@drawable/ic_exercise_place_marker"
-        app:layout_constraintTop_toTopOf="@id/map_view"
+        app:layout_constraintTop_toTopOf="@id/map_compose_view"
         app:layout_constraintBottom_toTopOf="@id/place_address_cl"
-        app:layout_constraintEnd_toEndOf="@id/map_view"
-        app:layout_constraintStart_toStartOf="@id/map_view"
+        app:layout_constraintEnd_toEndOf="@id/map_compose_view"
+        app:layout_constraintStart_toStartOf="@id/map_compose_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:tint="@color/black" />

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     // Image Loading
     implementation(libs.coil.compose)
 
+    // Map (KakaoMapView 공통 컴포저블 호스팅용)
+    implementation(libs.kakao.map)
+
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.splashscreen)

--- a/presentation/src/main/java/com/project200/presentation/compose/map/KakaoMapView.kt
+++ b/presentation/src/main/java/com/project200/presentation/compose/map/KakaoMapView.kt
@@ -1,4 +1,4 @@
-package com.project200.feature.matching.map.compose
+package com.project200.presentation.compose.map
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -25,13 +25,13 @@ import com.project200.presentation.compose.theme.ColorGray300
 import timber.log.Timber
 
 /**
+ * KakaoMap SDK v2 의 MapView 를 Compose 에 호스팅하는 공통 컴포넌트.
  *
- * MapView 를 AndroidView 로 호스팅하고,
- * 생명주기(resume/pause/finish)를 DisposableEffect 로 연결한다.
- * MapView 단일 인스턴스 생성, start()/MapReadyCallback 캡슐화, 준비된 KakaoMap 을
- * [onMapReady] 로 노출한다.
+ * MapView 를 AndroidView 로 호스팅하고, 생명주기(resume/pause/finish)를 DisposableEffect 로 연결한다.
+ * MapView 단일 인스턴스 생성, start()/MapReadyCallback 캡슐화, 준비된 KakaoMap 을 [onMapReady] 로 노출한다.
+ * 매칭 지도/장소 검색 등 지도를 쓰는 화면들이 공유한다.
  *
- * @param onMapReady 지도 준비 완료 시 KakaoMap 핸들 전달(여기서 MapViewManager 생성 등)
+ * @param onMapReady 지도 준비 완료 시 KakaoMap 핸들 전달(여기서 MapViewManager 생성/리스너 등록 등)
  * @param onMapError 지도 로딩 에러
  */
 @Composable


### PR DESCRIPTION
> ⚠️ 이 PR은 #553(#550) 위에 쌓인 stacked PR 입니다. base 를 `refactor/kakaomap-overlay-compose-550` 로 두었으니, #553 이 dev 에 머지된 뒤 base 를 dev 로 바꿔주세요. (머지 체인: #549 → #553 → 이 PR)

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#551

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#546에서 만든 `KakaoMapView` 컴포저블을 공통 모듈로 올리고, 지도를 쓰는 보조 화면 2곳(장소 검색)도 지도 본체를 Compose(ComposeView interop)로 전환했습니다.

- 공통 `KakaoMapView` 컴포저블을 `presentation` 모듈로 이동
  - `feature/matching` → `presentation`(`com.project200.presentation.compose.map`)
  - `presentation` 에 `libs.kakao.map` 의존성 추가
  - `MatchingMapScreen` 은 이동한 `KakaoMapView` 를 import (동작 동일)
  - 이제 매칭 지도 + 장소 검색 2곳이 하나의 `KakaoMapView` 를 공유
- `ExercisePlaceSearchFragment`(matching) 지도 본체 Compose 전환
  - 레이아웃 `com.kakao.vectormap.MapView` → `ComposeView`(`map_compose_view`), center marker 제약 갱신
  - `mapView.start(...)` 직접 호출 대신 `applyAppTheme { KakaoMapView(onMapReady = { ... }) }` 로 호스팅
  - `onMapReady` 에서 기존 로직(제스처 비활성화, `setOnCameraMoveEndListener`, 초기 위치) 그대로 유지
  - 수동 `onResume/onPause` 의 `resume/pause` 제거 → 컴포저블 `DisposableEffect` 가 처리
  - `fromScreenPoint` 좌표 참조 `binding.mapView.*` → `binding.mapComposeView.*` (ComposeView 가 동일 영역이라 동작 유지)
- `PlaceSearchFragment`(exercise) 지도 본체 Compose 전환
  - 위와 동일한 방식으로 전환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

