### PR TITLE
[Fix] 오프라인 실행 시 업데이트 확인 실패로 스플래시에서 멈추는 버그 수정 #555

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -47,7 +47,8 @@ class MainViewModel
                         }
                     }
                     .onFailure { error ->
-                        Timber.e(error, "ViewModel: 업데이트 확인 실패")
+                        Timber.e(error, "ViewModel: 업데이트 확인 실패 - NoUpdateNeeded로 진행")
+                        _updateCheckResult.value = UpdateCheckResult.NoUpdateNeeded
                     }
             }
         }

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -133,7 +133,7 @@ class MainViewModelTest {
         }
 
     @Test
-    fun `checkForUpdate - 실패해도 크래시하지 않는다`() =
+    fun `checkForUpdate - 실패해도 NoUpdateNeeded를 방출해 라우팅이 진행된다`() =
         runTest {
             // Given
             coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
@@ -145,7 +145,7 @@ class MainViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertThat(viewModel.updateCheckResult.value).isNull()
+            assertThat(viewModel.updateCheckResult.value).isEqualTo(UpdateCheckResult.NoUpdateNeeded)
         }
 
     @Test

--- a/data/src/main/java/com/project200/data/impl/AppUpdateRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AppUpdateRepositoryImpl.kt
@@ -20,16 +20,19 @@ class AppUpdateRepositoryImpl
         override suspend fun getUpdateInfo(): Result<UpdateInfo> {
             return runCatching {
                 // Remote Config 값 가져오기 및 활성화
-                val activated = firebaseRemoteConfig.fetchAndActivate().await()
-                if (activated) {
-                    Timber.tag("RemoteConfig")
-                        .d("RemoteConfig 가져오기 성공 및 활성화 완료")
-                } else {
-                    Timber.tag("RemoteConfig")
-                        .d("RemoteConfig 가져오기 실패 또는 변경 없음")
+                // 오프라인 등으로 fetch 실패 시 로컬 캐시/기본값(remote_config_defaults.xml)으로 계속 진행
+                try {
+                    val activated = firebaseRemoteConfig.fetchAndActivate().await()
+                    if (activated) {
+                        Timber.tag("RemoteConfig").d("RemoteConfig 가져오기 성공 및 활성화 완료")
+                    } else {
+                        Timber.tag("RemoteConfig").d("RemoteConfig 가져오기 실패 또는 변경 없음")
+                    }
+                } catch (e: Exception) {
+                    Timber.tag("RemoteConfig").w(e, "fetchAndActivate 실패 - 캐시/기본값 사용")
                 }
 
-                // 값 읽어오기
+                // 값 읽어오기 (fetch 실패 시 캐시 또는 remote_config_defaults.xml 반환)
                 val latestVersion = firebaseRemoteConfig.getLong(RemoteConfigKeys.LATEST_VERSION_CODE)
                 val minRequiredVersion = firebaseRemoteConfig.getLong(RemoteConfigKeys.MIN_REQUIRED_VERSION_CODE)
                 Timber.tag("RemoteConfig")


### PR DESCRIPTION
## 개요

비행기 모드 등 오프라인 상태로 앱을 실행하면 스플래시 화면에서 멈추는 버그를 수정합니다.

## 원인

- `AppUpdateRepositoryImpl.getUpdateInfo()`가 `fetchAndActivate().await()`를 `runCatching` 전체로 감싸고 있어, 네트워크 실패 시 `Result.failure()`를 반환
- `MainViewModel.checkForUpdate()`의 `onFailure` 핸들러가 로그만 남기고 `_updateCheckResult`에 값을 넣지 않아 옵저버가 실행되지 않음
- 결과적으로 `performRouting()`이 호출되지 않고 `isLoading`이 `true`로 유지되어 스플래시가 무한 지속

## 변경 내용

- `AppUpdateRepositoryImpl`: `fetchAndActivate()` 실패를 try-catch로 삼키고 로컬 캐시 / `remote_config_defaults.xml` 기본값으로 계속 진행
- `MainViewModel`: UseCase가 어떤 이유로든 실패하면 `NoUpdateNeeded`를 방출해 라우팅이 진행되는 안전망 추가
- `MainViewModelTest`: 실패 케이스 기대값을 `null` → `NoUpdateNeeded`로 갱신

## 트레이드오프

오프라인에서는 Remote Config를 받아올 수 없으므로 강제 업데이트 차단이 동작하지 않습니다. 기본값(`remote_config_defaults.xml`)이 `latest_version_code = 1`, `min_required_version_code = 1`로 설정되어 있어 현재 앱 버전 코드(≥ 1)에서는 업데이트 불필요로 판정됩니다.

## 확인 사항

- [ ] 비행기 모드에서 앱 실행 → 스플래시가 끝나고 다음 화면으로 진입
- [ ] 온라인에서 선택/강제 업데이트 동작 회귀 없음

Closes #555