### PR TITLE
[Fix] 온라인 전환 시 업데이트 재확인 및 강제 업데이트 처리 #559

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -114,6 +114,7 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
         navController = (supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment).navController
 
         setupViews()
+        viewModel.onContentShown()
     }
 
     private fun navigateToLogin() {
@@ -244,6 +245,12 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
                     Toast.makeText(this@MainActivity, R.string.error_token_refresh_failed, Toast.LENGTH_SHORT).show()
                     navigateToLogin()
                 }
+            }
+        }
+        lifecycleScope.launch {
+            viewModel.forceUpdateAfterReconnect.collectLatest {
+                Timber.d("재연결 후 강제 업데이트 필요 이벤트 수신")
+                showUpdateDialog(isForceUpdate = true)
             }
         }
     }

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -4,12 +4,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
 import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.domain.usecase.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -21,6 +26,7 @@ class MainViewModel
         private val checkForUpdateUseCase: CheckForUpdateUseCase,
         private val checkIsRegisteredUseCase: CheckIsRegisteredUseCase,
         private val loginUseCase: LoginUseCase,
+        private val networkMonitor: NetworkMonitor,
     ) : ViewModel() {
         private val _updateCheckResult = MutableLiveData<UpdateCheckResult>()
         val updateCheckResult: LiveData<UpdateCheckResult> = _updateCheckResult
@@ -30,6 +36,45 @@ class MainViewModel
 
         private val _showBottomNavigation = MutableLiveData<Boolean>()
         val showBottomNavigation: LiveData<Boolean> = _showBottomNavigation
+
+        private val _forceUpdateAfterReconnect = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        val forceUpdateAfterReconnect: SharedFlow<Unit> = _forceUpdateAfterReconnect.asSharedFlow()
+
+        private var isContentShown = false
+        private var wasOffline = false
+
+        init {
+            observeNetworkReconnection()
+        }
+
+        private fun observeNetworkReconnection() {
+            viewModelScope.launch {
+                networkMonitor.networkState.collect { isOnline ->
+                    if (isOnline && wasOffline && isContentShown) {
+                        recheckForUpdateOnReconnect()
+                    }
+                    wasOffline = !isOnline
+                }
+            }
+        }
+
+        private suspend fun recheckForUpdateOnReconnect() {
+            // onAvailable 직후 일시적 불안정 대비 딜레이
+            delay(RECONNECT_UPDATE_CHECK_DELAY_MS)
+            checkForUpdateUseCase()
+                .onSuccess { result ->
+                    if (result is UpdateCheckResult.UpdateAvailable && result.isForceUpdate) {
+                        _forceUpdateAfterReconnect.tryEmit(Unit)
+                    }
+                }
+                .onFailure { e ->
+                    Timber.w(e, "재연결 후 업데이트 확인 실패 - 무시")
+                }
+        }
+
+        fun onContentShown() {
+            isContentShown = true
+        }
 
         // 업데이트 확인
         fun checkForUpdate() {
@@ -68,5 +113,9 @@ class MainViewModel
 
         fun hideBottomNavigation() {
             _showBottomNavigation.value = false
+        }
+
+        companion object {
+            private const val RECONNECT_UPDATE_CHECK_DELAY_MS = 1500L
         }
     }

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -41,7 +41,7 @@ class MainViewModel
         val forceUpdateAfterReconnect: SharedFlow<Unit> = _forceUpdateAfterReconnect.asSharedFlow()
 
         private var isContentShown = false
-        private var wasOffline = false
+        private var wasOffline = !networkMonitor.isCurrentlyConnected()
 
         init {
             observeNetworkReconnection()

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -163,9 +163,10 @@ class MainViewModelTest {
     fun `재연결 - 콘텐츠 진입 후 오프라인에서 온라인으로 전환되면 강제 업데이트 이벤트를 방출한다`() =
         runTest {
             // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
-                UpdateCheckResult.UpdateAvailable(isForceUpdate = true)
-            )
+            coEvery { mockCheckForUpdateUseCase() } returns
+                Result.success(
+                    UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
+                )
             viewModel = createViewModel()
             viewModel.onContentShown()
 
@@ -186,9 +187,10 @@ class MainViewModelTest {
     fun `재연결 - 선택 업데이트면 강제 업데이트 이벤트를 방출하지 않는다`() =
         runTest {
             // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
-                UpdateCheckResult.UpdateAvailable(isForceUpdate = false)
-            )
+            coEvery { mockCheckForUpdateUseCase() } returns
+                Result.success(
+                    UpdateCheckResult.UpdateAvailable(isForceUpdate = false),
+                )
             viewModel = createViewModel()
             viewModel.onContentShown()
 
@@ -230,9 +232,10 @@ class MainViewModelTest {
     fun `재연결 - 콘텐츠 진입 전에는 온라인 전환이 업데이트 재확인을 트리거하지 않는다`() =
         runTest {
             // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
-                UpdateCheckResult.UpdateAvailable(isForceUpdate = true)
-            )
+            coEvery { mockCheckForUpdateUseCase() } returns
+                Result.success(
+                    UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
+                )
             viewModel = createViewModel()
             // onContentShown() 호출 안 함
 

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -56,6 +56,7 @@ class MainViewModelTest {
         Dispatchers.setMain(testDispatcher)
         networkStateFlow = MutableSharedFlow()
         every { mockNetworkMonitor.networkState } returns networkStateFlow
+        every { mockNetworkMonitor.isCurrentlyConnected() } returns true
     }
 
     @After
@@ -71,6 +72,40 @@ class MainViewModelTest {
             networkMonitor = mockNetworkMonitor,
         )
     }
+
+    @Test
+    fun `오프라인 콜드스타트 - 첫 온라인 전환에 업데이트를 재확인한다`() =
+        runTest {
+            // Given: 오프라인 상태로 시작
+            every { mockNetworkMonitor.isCurrentlyConnected() } returns false
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.runCurrent()
+            viewModel.onContentShown()
+
+            // When: 망이 붙어 첫 emit이 true로 옴 (false emit 없음)
+            launch { networkStateFlow.emit(true) }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 재확인이 일어난다
+            coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
+        }
+
+    @Test
+    fun `온라인 콜드스타트 - 첫 onAvailable emit에 재확인이 헛발 실행되지 않는다`() =
+        runTest {
+            // Given: 온라인 상태로 시작 (setUp 기본값)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.runCurrent()
+            viewModel.onContentShown()
+
+            // When: registerNetworkCallback 직후 시스템이 쏘는 onAvailable
+            launch { networkStateFlow.emit(true) }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 재확인 없음
+            coVerify(exactly = 0) { mockCheckForUpdateUseCase() }
+        }
 
     @Test
     fun `checkForUpdate - 업데이트가 필요하면 UpdateAvailable 결과를 반환한다`() =
@@ -172,6 +207,7 @@ class MainViewModelTest {
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.runCurrent()
 
             // When: offline → online 전환
             networkStateFlow.emit(false)
@@ -196,6 +232,7 @@ class MainViewModelTest {
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.runCurrent()
 
             // When: offline → online 전환
             networkStateFlow.emit(false)
@@ -217,6 +254,7 @@ class MainViewModelTest {
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.runCurrent()
 
             // When: offline → online 전환
             networkStateFlow.emit(false)
@@ -237,6 +275,7 @@ class MainViewModelTest {
                     UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
                 )
             viewModel = createViewModel()
+            testDispatcher.scheduler.runCurrent()
             // onContentShown() 호출 안 함
 
             // When: offline → online 전환

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -2,6 +2,7 @@ package com.project200.undabang.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
+import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
@@ -9,10 +10,13 @@ import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.domain.usecase.LoginUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -39,13 +43,19 @@ class MainViewModelTest {
     @MockK
     private lateinit var mockLoginUseCase: LoginUseCase
 
+    @MockK
+    private lateinit var mockNetworkMonitor: NetworkMonitor
+
     private lateinit var viewModel: MainViewModel
+    private lateinit var networkStateFlow: MutableSharedFlow<Boolean>
 
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        networkStateFlow = MutableSharedFlow()
+        every { mockNetworkMonitor.networkState } returns networkStateFlow
     }
 
     @After
@@ -58,6 +68,7 @@ class MainViewModelTest {
             checkForUpdateUseCase = mockCheckForUpdateUseCase,
             checkIsRegisteredUseCase = mockCheckIsRegisteredUseCase,
             loginUseCase = mockLoginUseCase,
+            networkMonitor = mockNetworkMonitor,
         )
     }
 
@@ -146,6 +157,92 @@ class MainViewModelTest {
 
             // Then
             assertThat(viewModel.updateCheckResult.value).isEqualTo(UpdateCheckResult.NoUpdateNeeded)
+        }
+
+    @Test
+    fun `재연결 - 콘텐츠 진입 후 오프라인에서 온라인으로 전환되면 강제 업데이트 이벤트를 방출한다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
+                UpdateCheckResult.UpdateAvailable(isForceUpdate = true)
+            )
+            viewModel = createViewModel()
+            viewModel.onContentShown()
+
+            val events = mutableListOf<Unit>()
+            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(events).hasSize(1)
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `재연결 - 선택 업데이트면 강제 업데이트 이벤트를 방출하지 않는다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
+                UpdateCheckResult.UpdateAvailable(isForceUpdate = false)
+            )
+            viewModel = createViewModel()
+            viewModel.onContentShown()
+
+            val events = mutableListOf<Unit>()
+            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(events).isEmpty()
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `재연결 - 업데이트 확인 실패 시 강제 업데이트 이벤트를 방출하지 않는다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
+            viewModel = createViewModel()
+            viewModel.onContentShown()
+
+            val events = mutableListOf<Unit>()
+            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(events).isEmpty()
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `재연결 - 콘텐츠 진입 전에는 온라인 전환이 업데이트 재확인을 트리거하지 않는다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(
+                UpdateCheckResult.UpdateAvailable(isForceUpdate = true)
+            )
+            viewModel = createViewModel()
+            // onContentShown() 호출 안 함
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: UseCase 호출 없음
+            coVerify(exactly = 0) { mockCheckForUpdateUseCase() }
         }
 
     @Test


### PR DESCRIPTION
## 개요

오프라인으로 진입한 뒤 온라인으로 전환됐을 때 업데이트를 재확인하고, 강제 업데이트가 필요하면 blocking 다이얼로그를 표시합니다. (#555 후속)

## 변경 내용

- `MainViewModel`: `NetworkMonitor.networkState`를 구독해 `false → true` 전환 + 콘텐츠 진입 후 조건에서 업데이트 재확인 트리거
- `MainViewModel`: `onAvailable` 직후 일시적 네트워크 불안정 대비 1.5초 딜레이 후 재확인
- `MainViewModel`: 재확인 실패 시 조용히 무시 (사용자 경험 유지)
- `MainViewModel`: 강제 업데이트 감지 시 `forceUpdateAfterReconnect` emit
- `MainActivity`: 콘텐츠 진입 시 `onContentShown()` 호출로 재확인 조건 활성화
- `MainActivity`: `forceUpdateAfterReconnect` 수집 → blocking 다이얼로그 표시

## 트레이드오프

- `onAvailable` 감지 후 1.5초 딜레이 동안 앱 사용 가능
- 재확인 실패 시 강제 업데이트를 차단하지 않음 (다음 재연결 또는 앱 재시작 때 재시도)

## 확인 사항

- [ ] 오프라인 진입 → 온라인 전환 → 강제 업데이트 다이얼로그 표시
- [ ] 오프라인 진입 → 온라인 전환 → 선택 업데이트는 다이얼로그 미표시
- [ ] 온라인 상태로 정상 진입 시 재확인 트리거 없음

Closes #559