### PR TITLE
[Refactor] 오프라인 진입을 위한 세션 판정과 서버 로그인 호출 분리 #556

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -18,7 +18,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
-import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.presentation.navigator.BottomNavigationController
@@ -33,6 +32,7 @@ import com.project200.undabang.oauth.TokenRefreshResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import net.openid.appauth.AuthorizationException
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -83,20 +83,36 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
                     when (val refreshResult = authManager.refreshAccessToken()) {
                         is TokenRefreshResult.Success -> {
                             Timber.i("Token refresh successful.")
-                            viewModel.login()
+                            viewModel.loginInBackground()
+                            proceedToContent()
                         }
-                        is TokenRefreshResult.Error,
+                        is TokenRefreshResult.Error -> {
+                            val ex = refreshResult.exception
+                            val isInvalidGrant =
+                                ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
+                                    ex.error == "invalid_grant"
+                            if (isInvalidGrant) {
+                                // forceLogoutFlow도 함께 발행되지만 명시적으로 처리
+                                Timber.w("invalid_grant - 로그인 화면으로 이동")
+                                navigateToLogin()
+                            } else {
+                                // 네트워크 오류 등 일시적 실패 - 오프라인으로 진입
+                                Timber.w("Token refresh network error, proceeding offline.")
+                                viewModel.loginInBackground()
+                                proceedToContent()
+                            }
+                        }
                         is TokenRefreshResult.NoRefreshToken,
                         is TokenRefreshResult.ConfigError,
                         -> {
-                            Timber.w("Token refresh failed or not possible. Navigating to Login.")
-                            if (refreshResult is TokenRefreshResult.Error) Timber.e(refreshResult.exception)
+                            Timber.w("Token refresh not possible (${refreshResult::class.simpleName}). Navigating to Login.")
                             navigateToLogin()
                         }
                     }
                 } else {
                     Timber.i("User is authorized and token is fresh.")
-                    viewModel.login()
+                    viewModel.loginInBackground()
+                    proceedToContent()
                 }
             } else {
                 Timber.i("User is not authorized.")
@@ -171,44 +187,31 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
     }
 
     private fun setupObservers() {
-        viewModel.updateCheckResult.observe(this) { result ->
-            when (result) {
-                is UpdateCheckResult.UpdateAvailable -> {
-                    showUpdateDialog(result.isForceUpdate)
-                    if (result.isForceUpdate) {
-                        isLoading = false
-                    } else {
+        lifecycleScope.launch {
+            viewModel.updateCheckResult.collectLatest { result ->
+                result ?: return@collectLatest
+                when (result) {
+                    is UpdateCheckResult.UpdateAvailable -> {
+                        showUpdateDialog(result.isForceUpdate)
+                        if (result.isForceUpdate) {
+                            isLoading = false
+                        } else {
+                            performRouting()
+                        }
+                    }
+                    is UpdateCheckResult.NoUpdateNeeded -> {
+                        Timber.d("업데이트 불필요")
                         performRouting()
                     }
                 }
-                is UpdateCheckResult.NoUpdateNeeded -> {
-                    Timber.d("업데이트 불필요")
-                    performRouting()
-                }
-                else -> {
-                    // 필요한 경우 다른 상태 처리
-                    Timber.d("UpdateCheckResult: Unhandled state or null")
-                    performRouting()
-                }
             }
         }
 
-        viewModel.loginResult.observe(this) { result ->
-            when (result) {
-                is BaseResult.Success -> {
-                    proceedToContent()
+        lifecycleScope.launch {
+            viewModel.showBottomNavigation.collectLatest { show ->
+                if (::binding.isInitialized) {
+                    binding.bottomNavigation.isVisible = show
                 }
-                is BaseResult.Error -> {
-                    navigateToLogin()
-                }
-            }
-        }
-
-        viewModel.showBottomNavigation.observe(this) { show ->
-            if (show) {
-                showBottomNavigation()
-            } else {
-                hideBottomNavigation()
             }
         }
     }

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -1,20 +1,20 @@
 package com.project200.undabang.main
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
-import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.domain.usecase.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -24,24 +24,21 @@ class MainViewModel
     @Inject
     constructor(
         private val checkForUpdateUseCase: CheckForUpdateUseCase,
-        private val checkIsRegisteredUseCase: CheckIsRegisteredUseCase,
         private val loginUseCase: LoginUseCase,
         private val networkMonitor: NetworkMonitor,
     ) : ViewModel() {
-        private val _updateCheckResult = MutableLiveData<UpdateCheckResult>()
-        val updateCheckResult: LiveData<UpdateCheckResult> = _updateCheckResult
+        private val _updateCheckResult = MutableStateFlow<UpdateCheckResult?>(null)
+        val updateCheckResult: StateFlow<UpdateCheckResult?> = _updateCheckResult.asStateFlow()
 
-        private val _loginResult = MutableLiveData<BaseResult<Unit>>()
-        val loginResult: LiveData<BaseResult<Unit>> = _loginResult
-
-        private val _showBottomNavigation = MutableLiveData<Boolean>()
-        val showBottomNavigation: LiveData<Boolean> = _showBottomNavigation
+        private val _showBottomNavigation = MutableStateFlow(false)
+        val showBottomNavigation: StateFlow<Boolean> = _showBottomNavigation.asStateFlow()
 
         private val _forceUpdateAfterReconnect = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
         val forceUpdateAfterReconnect: SharedFlow<Unit> = _forceUpdateAfterReconnect.asSharedFlow()
 
         private var isContentShown = false
         private var wasOffline = false
+        private var serverLoginPending = false
 
         init {
             observeNetworkReconnection()
@@ -51,6 +48,9 @@ class MainViewModel
             viewModelScope.launch {
                 networkMonitor.networkState.collect { isOnline ->
                     if (isOnline && wasOffline && isContentShown) {
+                        if (serverLoginPending) {
+                            loginInBackground()
+                        }
                         recheckForUpdateOnReconnect()
                     }
                     wasOffline = !isOnline
@@ -78,9 +78,7 @@ class MainViewModel
 
         // 업데이트 확인
         fun checkForUpdate() {
-            if (_updateCheckResult.value != null) {
-                return
-            } // 이미 체크했다면 스킵
+            if (_updateCheckResult.value != null) return // 이미 체크했다면 스킵
 
             viewModelScope.launch {
                 checkForUpdateUseCase()
@@ -88,7 +86,7 @@ class MainViewModel
                         _updateCheckResult.value = result
                         when (result) {
                             is UpdateCheckResult.UpdateAvailable -> Timber.d("업데이트 가능 isForce: ${result.isForceUpdate}")
-                            is UpdateCheckResult.NoUpdateNeeded -> Timber.d("업데이트 불가능")
+                            is UpdateCheckResult.NoUpdateNeeded -> Timber.d("업데이트 불필요")
                         }
                     }
                     .onFailure { error ->
@@ -98,12 +96,18 @@ class MainViewModel
             }
         }
 
-        // 로그인
-        fun login() {
+        // POST /login — 진입 게이트와 무관하게 백그라운드에서 실행
+        // 실패 시 serverLoginPending = true, 재연결 시 자동 재시도
+        fun loginInBackground() {
             viewModelScope.launch {
                 val result = loginUseCase()
-                checkIsRegisteredUseCase()
-                _loginResult.value = result
+                if (result is BaseResult.Success) {
+                    serverLoginPending = false
+                    Timber.d("서버 로그인 성공")
+                } else {
+                    serverLoginPending = true
+                    Timber.w("서버 로그인 실패 - 재연결 시 재시도 예정")
+                }
             }
         }
 

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -1,12 +1,10 @@
 package com.project200.undabang.main
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
-import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.domain.usecase.LoginUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -31,14 +29,8 @@ class MainViewModelTest {
     @get:Rule
     val mockkRule = MockKRule(this)
 
-    @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
-
     @MockK
     private lateinit var mockCheckForUpdateUseCase: CheckForUpdateUseCase
-
-    @MockK
-    private lateinit var mockCheckIsRegisteredUseCase: CheckIsRegisteredUseCase
 
     @MockK
     private lateinit var mockLoginUseCase: LoginUseCase
@@ -66,7 +58,6 @@ class MainViewModelTest {
     private fun createViewModel(): MainViewModel {
         return MainViewModel(
             checkForUpdateUseCase = mockCheckForUpdateUseCase,
-            checkIsRegisteredUseCase = mockCheckIsRegisteredUseCase,
             loginUseCase = mockLoginUseCase,
             networkMonitor = mockNetworkMonitor,
         )
@@ -167,15 +158,17 @@ class MainViewModelTest {
                 Result.success(
                     UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
                 )
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
             viewModel = createViewModel()
             viewModel.onContentShown()
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.advanceUntilIdle() // collectJob이 구독을 시작한 뒤 emit
 
-            // When: offline → online 전환
-            networkStateFlow.emit(false)
-            networkStateFlow.emit(true)
+            // When: offline → online 전환 (emit은 collect lambda 완료를 대기하므로 별도 코루틴으로)
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
@@ -191,15 +184,17 @@ class MainViewModelTest {
                 Result.success(
                     UpdateCheckResult.UpdateAvailable(isForceUpdate = false),
                 )
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
             viewModel = createViewModel()
             viewModel.onContentShown()
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.advanceUntilIdle()
 
             // When: offline → online 전환
-            networkStateFlow.emit(false)
-            networkStateFlow.emit(true)
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
@@ -212,15 +207,17 @@ class MainViewModelTest {
         runTest {
             // Given
             coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
             viewModel = createViewModel()
             viewModel.onContentShown()
 
             val events = mutableListOf<Unit>()
             val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
+            testDispatcher.scheduler.advanceUntilIdle()
 
             // When: offline → online 전환
-            networkStateFlow.emit(false)
-            networkStateFlow.emit(true)
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
@@ -240,8 +237,8 @@ class MainViewModelTest {
             // onContentShown() 호출 안 함
 
             // When: offline → online 전환
-            networkStateFlow.emit(false)
-            networkStateFlow.emit(true)
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then: UseCase 호출 없음
@@ -249,39 +246,64 @@ class MainViewModelTest {
         }
 
     @Test
-    fun `login - 성공하면 Success 결과를 반환한다`() =
+    fun `loginInBackground - 서버 로그인을 백그라운드에서 호출한다`() =
         runTest {
             // Given
             coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            coEvery { mockCheckIsRegisteredUseCase() } returns true
-
             viewModel = createViewModel()
 
             // When
-            viewModel.login()
+            viewModel.loginInBackground()
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertThat(viewModel.loginResult.value).isInstanceOf(BaseResult.Success::class.java)
-            coVerify { mockLoginUseCase() }
-            coVerify { mockCheckIsRegisteredUseCase() }
+            coVerify(exactly = 1) { mockLoginUseCase() }
         }
 
     @Test
-    fun `login - 실패하면 Error 결과를 반환한다`() =
+    fun `loginInBackground - 실패하면 재연결 시 재시도한다`() =
         runTest {
-            // Given
-            coEvery { mockLoginUseCase() } returns BaseResult.Error("ERROR", "로그인 실패")
-            coEvery { mockCheckIsRegisteredUseCase() } returns false
-
+            // Given: 처음엔 실패, 이후엔 성공
+            coEvery { mockLoginUseCase() } returns
+                BaseResult.Error("NETWORK_ERROR", "네트워크 오류") andThen
+                BaseResult.Success(Unit)
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
             viewModel = createViewModel()
+            viewModel.onContentShown()
 
-            // When
-            viewModel.login()
+            // When: 최초 로그인 실패
+            viewModel.loginInBackground()
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Then
-            assertThat(viewModel.loginResult.value).isInstanceOf(BaseResult.Error::class.java)
+            // When: offline → online 재연결
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 총 2회 호출 (최초 + 재시도)
+            coVerify(exactly = 2) { mockLoginUseCase() }
+        }
+
+    @Test
+    fun `loginInBackground - 성공하면 재연결 시 재시도하지 않는다`() =
+        runTest {
+            // Given
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
+            viewModel = createViewModel()
+            viewModel.onContentShown()
+
+            // When: 최초 로그인 성공
+            viewModel.loginInBackground()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // When: offline → online 재연결
+            launch { networkStateFlow.emit(false) }
+            launch { networkStateFlow.emit(true) }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 최초 1회만 호출
+            coVerify(exactly = 1) { mockLoginUseCase() }
         }
 
     @Test

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -13,8 +13,8 @@ import com.project200.domain.repository.AuthRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import java.io.IOException
 import timber.log.Timber
+import java.io.IOException
 import java.time.LocalDate
 import javax.inject.Inject
 

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -8,10 +8,12 @@ import com.project200.data.dto.PostSignUpRequest
 import com.project200.data.local.PreferenceManager
 import com.project200.data.utils.apiCallBuilder
 import com.project200.domain.model.BaseResult
+import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.repository.AuthRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import timber.log.Timber
 import java.time.LocalDate
 import javax.inject.Inject
@@ -23,17 +25,24 @@ class AuthRepositoryImpl
         private val spManager: PreferenceManager,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) : AuthRepository {
-        override suspend fun checkIsRegistered(): Boolean =
+        override suspend fun checkIsRegistered(): RegistrationStatus =
             withContext(ioDispatcher) {
                 try {
                     val response = apiService.getIsRegistered()
                     response.data?.let { spManager.saveMemberId(it.memberId) }
-                    response.data?.isRegistered ?: false
+                    if (response.data?.isRegistered == true) {
+                        RegistrationStatus.Registered
+                    } else {
+                        RegistrationStatus.Unregistered
+                    }
                 } catch (e: CancellationException) {
                     throw e
+                } catch (e: IOException) {
+                    Timber.tag(TAG).w("checkIsRegistered network error: $e")
+                    RegistrationStatus.Indeterminate
                 } catch (e: Exception) {
-                    Timber.tag(TAG).d("checkIsRegistered failed: $e")
-                    false
+                    Timber.tag(TAG).w("checkIsRegistered failed: $e")
+                    RegistrationStatus.Indeterminate
                 }
             }
 

--- a/domain/src/main/java/com/project200/domain/model/RegistrationStatus.kt
+++ b/domain/src/main/java/com/project200/domain/model/RegistrationStatus.kt
@@ -1,0 +1,7 @@
+package com.project200.domain.model
+
+sealed class RegistrationStatus {
+    object Registered : RegistrationStatus()
+    object Unregistered : RegistrationStatus()
+    object Indeterminate : RegistrationStatus() // 네트워크 오류 등으로 확인 불가
+}

--- a/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
@@ -1,10 +1,11 @@
 package com.project200.domain.repository
 
 import com.project200.domain.model.BaseResult
+import com.project200.domain.model.RegistrationStatus
 import java.time.LocalDate
 
 interface AuthRepository {
-    suspend fun checkIsRegistered(): Boolean
+    suspend fun checkIsRegistered(): RegistrationStatus
     suspend fun login(): BaseResult<Unit>
     suspend fun logout(): BaseResult<Unit>
     suspend fun signUp(gender: String, nickname: String, birth: LocalDate): BaseResult<Unit>

--- a/domain/src/main/java/com/project200/domain/usecase/CheckIsRegisteredUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/CheckIsRegisteredUseCase.kt
@@ -1,12 +1,13 @@
 package com.project200.domain.usecase
 
+import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.repository.AuthRepository
 import javax.inject.Inject
 
 class CheckIsRegisteredUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(): Boolean {
+    suspend operator fun invoke(): RegistrationStatus {
         return authRepository.checkIsRegistered()
     }
 }

--- a/domain/src/test/java/com/project200/domain/usecase/CheckIsRegisteredUseCaseTest.kt
+++ b/domain/src/test/java/com/project200/domain/usecase/CheckIsRegisteredUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.project200.domain.usecase
 
 import com.google.common.truth.Truth.assertThat
+import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.repository.AuthRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -29,28 +30,41 @@ class CheckIsRegisteredUseCaseTest {
     }
 
     @Test
-    fun `invoke 호출 시 등록된 사용자면 true 반환`() = runTest {
+    fun `invoke 호출 시 등록된 사용자면 Registered 반환`() = runTest {
         // Given
-        coEvery { mockRepository.checkIsRegistered() } returns true
+        coEvery { mockRepository.checkIsRegistered() } returns RegistrationStatus.Registered
 
         // When
         val result = useCase()
 
         // Then
         coVerify(exactly = 1) { mockRepository.checkIsRegistered() }
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(RegistrationStatus.Registered)
     }
 
     @Test
-    fun `invoke 호출 시 등록되지 않은 사용자면 false 반환`() = runTest {
+    fun `invoke 호출 시 등록되지 않은 사용자면 Unregistered 반환`() = runTest {
         // Given
-        coEvery { mockRepository.checkIsRegistered() } returns false
+        coEvery { mockRepository.checkIsRegistered() } returns RegistrationStatus.Unregistered
 
         // When
         val result = useCase()
 
         // Then
         coVerify(exactly = 1) { mockRepository.checkIsRegistered() }
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(RegistrationStatus.Unregistered)
+    }
+
+    @Test
+    fun `invoke 호출 시 확인 불가면 Indeterminate 반환`() = runTest {
+        // Given
+        coEvery { mockRepository.checkIsRegistered() } returns RegistrationStatus.Indeterminate
+
+        // When
+        val result = useCase()
+
+        // Then
+        coVerify(exactly = 1) { mockRepository.checkIsRegistered() }
+        assertThat(result).isEqualTo(RegistrationStatus.Indeterminate)
     }
 }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.project200.domain.model.BaseResult
+import com.project200.undabang.presentation.R as PresentationR
 import com.project200.presentation.base.BindingActivity
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.undabang.auth.register.RegisterActivity
@@ -141,7 +142,13 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
         viewModel.loginResult.observe(this) { result ->
             when (result) {
                 is BaseResult.Success -> appNavigator.navigateToMain(this)
-                is BaseResult.Error -> startActivity(Intent(this@LoginActivity, RegisterActivity::class.java))
+                is BaseResult.Error -> {
+                    if (result.errorCode == "NETWORK_ERROR") {
+                        Toast.makeText(this, PresentationR.string.network_error, Toast.LENGTH_SHORT).show()
+                    } else {
+                        startActivity(Intent(this@LoginActivity, RegisterActivity::class.java))
+                    }
+                }
             }
         }
         viewModel.fcmTokenEvent.observe(this) { result ->

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.project200.domain.model.BaseResult
-import com.project200.undabang.presentation.R as PresentationR
 import com.project200.presentation.base.BindingActivity
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.undabang.auth.register.RegisterActivity
@@ -26,6 +25,7 @@ import net.openid.appauth.AuthorizationService
 import net.openid.appauth.TokenResponse
 import timber.log.Timber
 import javax.inject.Inject
+import com.project200.undabang.presentation.R as PresentationR
 
 @AndroidEntryPoint
 class LoginActivity : BindingActivity<ActivityLoginBinding>() {


### PR DESCRIPTION
## 어떤 변경인가요?

오프라인 상태에서도 유효한 로컬 토큰이 있으면 앱에 진입할 수 있도록 진입 판정을 로컬 토큰 기반으로 분리하고, `POST /login` 호출을 진입 게이트와 무관하게 백그라운드에서 처리합니다.

- `checkIsRegistered()` 반환 타입을 `Boolean` → `RegistrationStatus` (Registered / Unregistered / Indeterminate) 3분기로 변경 — 네트워크 에러를 미가입으로 잘못 처리하던 버그 수정
- `MainViewModel.login()` → `loginInBackground()` 로 전환 — 성공 여부와 무관하게 진입, 실패 시 `serverLoginPending = true` 플래그로 재연결 시 자동 재시도
- `MainActivity.performRouting()` — 토큰 갱신 네트워크 에러는 오프라인으로 진입 허용, `invalid_grant` 는 기존대로 로그인 화면
- `LoginActivity.setupObservers()` — `POST /login` 에러 중 `NETWORK_ERROR` 는 토스트만, 401(미가입)만 `RegisterActivity` 로 이동

## 진입 경우의 수 (변경 후)

| 상황 | 동작 |
|---|---|
| 오프라인 + 토큰 유효 | 진입. `POST /login` 재연결 시 재시도 |
| 오프라인 + 토큰 만료 | 진입. 재연결 시 갱신 후 재시도 |
| 재연결 후 `POST /login` 성공 | 계속 |
| 재연결 후 `POST /login` 실패 | 다음 재연결 시 재시도 |
| 재연결 후 `invalid_grant` | 강제 로그아웃 (기존 `forceLogoutFlow` 경로) |
| `NoRefreshToken` / `ConfigError` | 로그인 화면 |

## 미결 사항

- `loginInBackground()` 가 401 (회원 없음) 응답을 받는 경우 현재 `serverLoginPending = true` 로 처리해 재시도하지만, 401 은 영구 실패이므로 토스트 + 로그인 화면으로 처리해야 함 — 별도 이슈로 분리 예정

## 테스트

- `MainViewModelTest` — `loginInBackground` 성공/실패/재시도 3개 케이스 추가
- 수동 확인 항목: 비행기 모드 진입, 재연결 후 갱신 성공, 리프레시 토큰 무효 세 경로

Closes #556

<!-- 아래 안내 문구는 유지해주세요 -->