### PR TITLE
refactor: EntryState 기반 앱 진입 라우팅 재구성

### DIFF
--- a/app/src/main/java/com/project200/undabang/main/EntryState.kt
+++ b/app/src/main/java/com/project200/undabang/main/EntryState.kt
@@ -2,7 +2,10 @@ package com.project200.undabang.main
 
 sealed class EntryState {
     object Loading : EntryState()
+
     object Content : EntryState()
+
     object Login : EntryState()
+
     data class ForceUpdate(val fromReconnect: Boolean) : EntryState()
 }

--- a/app/src/main/java/com/project200/undabang/main/EntryState.kt
+++ b/app/src/main/java/com/project200/undabang/main/EntryState.kt
@@ -1,0 +1,8 @@
+package com.project200.undabang.main
+
+sealed class EntryState {
+    object Loading : EntryState()
+    object Content : EntryState()
+    object Login : EntryState()
+    data class ForceUpdate(val fromReconnect: Boolean) : EntryState()
+}

--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -28,7 +28,6 @@ import com.project200.presentation.utils.KeyboardUtils.hideKeyboardOnTouchOutsid
 import com.project200.undabang.R
 import com.project200.undabang.databinding.ActivityMainBinding
 import com.project200.undabang.oauth.AuthManager
-import com.project200.undabang.oauth.AuthStateManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
-import com.project200.domain.model.UpdateCheckResult
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.presentation.navigator.BottomNavigationController
 import com.project200.presentation.update.UpdateDialogFragment
@@ -30,11 +29,9 @@ import com.project200.undabang.R
 import com.project200.undabang.databinding.ActivityMainBinding
 import com.project200.undabang.oauth.AuthManager
 import com.project200.undabang.oauth.AuthStateManager
-import com.project200.undabang.oauth.TokenRefreshResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import net.openid.appauth.AuthorizationException
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -43,8 +40,6 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
     private val viewModel: MainViewModel by viewModels()
 
     @Inject lateinit var authManager: AuthManager
-
-    @Inject lateinit var authStateManager: AuthStateManager
 
     @Inject lateinit var appNavigator: ActivityNavigator
     private lateinit var navController: NavController
@@ -74,7 +69,6 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
 
         setupObservers()
         observeAuthEvents()
-        viewModel.startEntry()
     }
 
     private fun showContentOnce() {
@@ -84,10 +78,6 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
         setContentView(binding.root)
         navController = (supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment).navController
         setupViews()
-    }
-
-    private fun navigateToLogin() {
-        appNavigator.navigateToLogin(this)
     }
 
     private fun setupViews() {
@@ -194,16 +184,7 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
         lifecycleScope.launch {
             authManager.forceLogoutFlow.collectLatest {
                 Timber.d("토큰 재발급 실패, 강제 로그아웃 이벤트 수신")
-                runOnUiThread {
-                    Toast.makeText(this@MainActivity, R.string.error_token_refresh_failed, Toast.LENGTH_SHORT).show()
-                    navigateToLogin()
-                }
-            }
-        }
-        lifecycleScope.launch {
-            viewModel.forceUpdateAfterReconnect.collectLatest {
-                Timber.d("재연결 후 강제 업데이트 필요 이벤트 수신")
-                showUpdateDialog(isForceUpdate = true)
+                Toast.makeText(this@MainActivity, R.string.error_token_refresh_failed, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/project200/undabang/main/MainActivity.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainActivity.kt
@@ -14,7 +14,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
@@ -46,9 +48,10 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
 
     @Inject lateinit var appNavigator: ActivityNavigator
     private lateinit var navController: NavController
-    private var isLoading = true // 스플래시 화면 유지를 위한 플래그
+
     private lateinit var binding: ActivityMainBinding
     private lateinit var requestNotificationPermissionLauncher: ActivityResultLauncher<String>
+    private var contentShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -56,7 +59,7 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
         super.onCreate(savedInstanceState)
 
         // 스플래시 화면을 계속 보여줄 조건 설정
-        splashScreen.setKeepOnScreenCondition { isLoading }
+        splashScreen.setKeepOnScreenCondition { viewModel.entryState.value is EntryState.Loading }
 
         requestNotificationPermissionLauncher =
             registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
@@ -70,71 +73,20 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
         checkNotificationPermission()
 
         setupObservers()
-        viewModel.checkForUpdate()
         observeAuthEvents()
+        viewModel.startEntry()
     }
 
-    private fun performRouting() {
-        lifecycleScope.launch {
-            val currentAuthState = authStateManager.getCurrent()
-            if (currentAuthState.isAuthorized) {
-                if (currentAuthState.needsTokenRefresh) {
-                    Timber.i("Token needs refresh. Attempting refresh...")
-                    when (val refreshResult = authManager.refreshAccessToken()) {
-                        is TokenRefreshResult.Success -> {
-                            Timber.i("Token refresh successful.")
-                            viewModel.loginInBackground()
-                            proceedToContent()
-                        }
-                        is TokenRefreshResult.Error -> {
-                            val ex = refreshResult.exception
-                            val isInvalidGrant =
-                                ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
-                                    ex.error == "invalid_grant"
-                            if (isInvalidGrant) {
-                                // forceLogoutFlow도 함께 발행되지만 명시적으로 처리
-                                Timber.w("invalid_grant - 로그인 화면으로 이동")
-                                navigateToLogin()
-                            } else {
-                                // 네트워크 오류 등 일시적 실패 - 오프라인으로 진입
-                                Timber.w("Token refresh network error, proceeding offline.")
-                                viewModel.loginInBackground()
-                                proceedToContent()
-                            }
-                        }
-                        is TokenRefreshResult.NoRefreshToken,
-                        is TokenRefreshResult.ConfigError,
-                        -> {
-                            Timber.w("Token refresh not possible (${refreshResult::class.simpleName}). Navigating to Login.")
-                            navigateToLogin()
-                        }
-                    }
-                } else {
-                    Timber.i("User is authorized and token is fresh.")
-                    viewModel.loginInBackground()
-                    proceedToContent()
-                }
-            } else {
-                Timber.i("User is not authorized.")
-                navigateToLogin()
-            }
-        }
-    }
-
-    private fun proceedToContent() {
-        isLoading = false // 스플래시 종료
-
+    private fun showContentOnce() {
+        if (contentShown) return
+        contentShown = true
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
         navController = (supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment).navController
-
         setupViews()
-        viewModel.onContentShown()
     }
 
     private fun navigateToLogin() {
-        isLoading = false // 스플래시 종료
         appNavigator.navigateToLogin(this)
     }
 
@@ -188,29 +140,27 @@ class MainActivity : AppCompatActivity(), BottomNavigationController {
 
     private fun setupObservers() {
         lifecycleScope.launch {
-            viewModel.updateCheckResult.collectLatest { result ->
-                result ?: return@collectLatest
-                when (result) {
-                    is UpdateCheckResult.UpdateAvailable -> {
-                        showUpdateDialog(result.isForceUpdate)
-                        if (result.isForceUpdate) {
-                            isLoading = false
-                        } else {
-                            performRouting()
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.entryState.collect { state ->
+                        when (state) {
+                            EntryState.Loading -> Unit
+                            EntryState.Content -> showContentOnce()
+                            EntryState.Login -> {
+                                appNavigator.navigateToLogin(this@MainActivity)
+                                finish()
+                            }
+                            is EntryState.ForceUpdate -> showUpdateDialog(isForceUpdate = true)
                         }
                     }
-                    is UpdateCheckResult.NoUpdateNeeded -> {
-                        Timber.d("업데이트 불필요")
-                        performRouting()
-                    }
                 }
-            }
-        }
-
-        lifecycleScope.launch {
-            viewModel.showBottomNavigation.collectLatest { show ->
-                if (::binding.isInitialized) {
-                    binding.bottomNavigation.isVisible = show
+                launch {
+                    viewModel.optionalUpdate.collect { show ->
+                        if (show) {
+                            showUpdateDialog(isForceUpdate = false)
+                            viewModel.onOptionalUpdateShown()
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -11,12 +11,11 @@ import com.project200.undabang.oauth.AuthManager
 import com.project200.undabang.oauth.AuthStateManager
 import com.project200.undabang.oauth.TokenRefreshResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import net.openid.appauth.AuthorizationException
@@ -34,17 +33,6 @@ class MainViewModel
         private val authManager: AuthManager,
         private val authStateManager: AuthStateManager,
     ) : ViewModel() {
-        private val _updateCheckResult = MutableStateFlow<UpdateCheckResult?>(null)
-        val updateCheckResult: StateFlow<UpdateCheckResult?> = _updateCheckResult.asStateFlow()
-
-        private val _showBottomNavigation = MutableStateFlow(false)
-        val showBottomNavigation: StateFlow<Boolean> = _showBottomNavigation.asStateFlow()
-
-        private val _forceUpdateAfterReconnect = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-        val forceUpdateAfterReconnect: SharedFlow<Unit> = _forceUpdateAfterReconnect.asSharedFlow()
-
-        private var wasOffline = !networkMonitor.isCurrentlyConnected()
-
         private val _entryState = MutableStateFlow<EntryState>(EntryState.Loading)
         val entryState: StateFlow<EntryState> = _entryState.asStateFlow()
 
@@ -52,30 +40,45 @@ class MainViewModel
         private val _optionalUpdate = MutableStateFlow(false)
         val optionalUpdate: StateFlow<Boolean> = _optionalUpdate.asStateFlow()
 
+        private var wasOffline = !networkMonitor.isCurrentlyConnected()
+
+        private var registrationJob: Job? = null
         private var serverLoginPending = false
 
         init {
             observeNetworkReconnection()
+            observeForceLogout()
+            startEntry()
         }
 
-        /** onCreate에서 1회. 회전 재생성 시 StateFlow 값이 살아 있어 자동 멱등 */
-        fun startEntry() {
-            if (_entryState.value != EntryState.Loading) return
+        /**
+         * 진입 시 업데이트 확인 -> 토큰 확인
+         * 이후 진입 상태를 업데이트하여 라우팅
+         */
+        private fun startEntry() {
             viewModelScope.launch {
-                val update = checkForUpdateUseCase().getOrElse {
-                    // 업데이트 확인 실패. 오프라인이라고 간주하고 진행
-                    UpdateCheckResult.NoUpdateNeeded
-                }
-                if (update is UpdateCheckResult.UpdateAvailable) {
-                    if (update.isForceUpdate) {
-                        _entryState.value = EntryState.ForceUpdate(fromReconnect = false)
-                        return@launch
+                try {
+                    val update = checkForUpdateUseCase().getOrElse {
+                        Timber.e(it, "업데이트 확인 실패 - NoUpdateNeeded로 진행")
+                        UpdateCheckResult.NoUpdateNeeded
                     }
-                    _optionalUpdate.value = true // 선택 업데이트는 라우팅과 병행 (기존 동작 유지)
+                    if (update is UpdateCheckResult.UpdateAvailable) {
+                        if (update.isForceUpdate) {
+                            _entryState.compareAndSet(EntryState.Loading, EntryState.ForceUpdate(fromReconnect = false))
+                            return@launch
+                        }
+                        _optionalUpdate.value = true
+                    }
+                    routeByAuth()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "진입 플로우 실패 - 로그인 화면으로 폴백")
+                    _entryState.value = EntryState.Login
                 }
-                routeByAuth()
             }
         }
+
         private suspend fun routeByAuth() {
             val state = authStateManager.getCurrent()
             if (!state.isAuthorized) {
@@ -83,11 +86,12 @@ class MainViewModel
                 return
             }
             if (state.needsTokenRefresh) {
-                when (val r = authManager.refreshAccessToken()) {
+                when (val result = authManager.refreshAccessToken()) {
                     is TokenRefreshResult.Success -> Unit
                     is TokenRefreshResult.Error -> {
-                        val ex = r.exception
-                        val invalidGrant = ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
+                        val ex = result.exception
+                        val invalidGrant =
+                            ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
                                 ex.error == "invalid_grant"
                         if (invalidGrant) {
                             _entryState.value = EntryState.Login
@@ -95,16 +99,27 @@ class MainViewModel
                         }
                         Timber.w("Token refresh 일시 실패 - 오프라인 진입")
                     }
+
                     is TokenRefreshResult.NoRefreshToken,
                     is TokenRefreshResult.ConfigError,
-                        -> {
+                    -> {
                         _entryState.value = EntryState.Login
                         return
                     }
                 }
             }
             ensureFcmRegistration()
-            _entryState.value = EntryState.Content
+            _entryState.compareAndSet(EntryState.Loading, EntryState.Content)
+        }
+
+        /** 사용 중 invalid_grant */
+        private fun observeForceLogout() {
+            viewModelScope.launch {
+                authManager.forceLogoutFlow.collect {
+                    Timber.w("강제 로그아웃 이벤트 - Login 전이")
+                    _entryState.value = EntryState.Login
+                }
+            }
         }
 
         /** 선택 업데이트 다이얼로그 표시 완료 */
@@ -116,6 +131,9 @@ class MainViewModel
             viewModelScope.launch {
                 networkMonitor.networkState.collect { isOnline ->
                     if (isOnline && wasOffline && _entryState.value is EntryState.Content) {
+                        if (serverLoginPending) {
+                            ensureFcmRegistration() // 실패했던 FCM 등록 재시도
+                        }
                         recheckForUpdateOnReconnect()
                     }
                     wasOffline = !isOnline
@@ -124,43 +142,36 @@ class MainViewModel
         }
 
         private suspend fun recheckForUpdateOnReconnect() {
+            // onAvailable 직후 일시적 불안정 대비 딜레이
             delay(RECONNECT_UPDATE_CHECK_DELAY_MS.milliseconds)
             checkForUpdateUseCase()
                 .onSuccess { result ->
                     if (result is UpdateCheckResult.UpdateAvailable && result.isForceUpdate) {
-                        _entryState.value = EntryState.ForceUpdate(fromReconnect = true)
+                        _entryState.compareAndSet(
+                            EntryState.Content,
+                            EntryState.ForceUpdate(fromReconnect = true),
+                        )
                     }
                 }
                 .onFailure { Timber.w(it, "재연결 후 업데이트 확인 실패 - 무시") }
         }
 
-        // 업데이트 확인
-        fun checkForUpdate() {
-            if (_updateCheckResult.value != null) return // 이미 체크했다면 스킵
-
-            viewModelScope.launch {
-                checkForUpdateUseCase()
-                    .onSuccess { result ->
-                        _updateCheckResult.value = result
-                        when (result) {
-                            is UpdateCheckResult.UpdateAvailable -> Timber.d("업데이트 가능 isForce: ${result.isForceUpdate}")
-                            is UpdateCheckResult.NoUpdateNeeded -> Timber.d("업데이트 불필요")
-                        }
-                    }
-                    .onFailure { error ->
-                        Timber.e(error, "ViewModel: 업데이트 확인 실패 - NoUpdateNeeded로 진행")
-                        _updateCheckResult.value = UpdateCheckResult.NoUpdateNeeded
-                    }
-            }
-        }
-
+        // FCM 토큰 등록
         private fun ensureFcmRegistration() {
-            viewModelScope.launch {
-                val result = loginUseCase()
-                serverLoginPending = result !is BaseResult.Success  // 실패 시 재연결 때 재시도
-            }
+            // 재시도 중 재연결이 겹치면 POST /login이 중복 발행 방지
+            if (registrationJob?.isActive == true) return
+            registrationJob =
+                viewModelScope.launch {
+                    serverLoginPending = true
+                    val result = loginUseCase()
+                    if (result is BaseResult.Success) {
+                        serverLoginPending = false
+                        Timber.d("서버 로그인(FCM 등록) 성공")
+                    } else {
+                        Timber.w("서버 로그인 실패 - 재연결 시 재시도 예정")
+                    }
+                }
         }
-
 
         companion object {
             private const val RECONNECT_UPDATE_CHECK_DELAY_MS = 1500L

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -160,9 +160,9 @@ class MainViewModel
         private fun ensureFcmRegistration() {
             // 재시도 중 재연결이 겹치면 POST /login이 중복 발행 방지
             if (registrationJob?.isActive == true) return
+            serverLoginPending = true
             registrationJob =
                 viewModelScope.launch {
-                    serverLoginPending = true
                     val result = loginUseCase()
                     if (result is BaseResult.Success) {
                         serverLoginPending = false

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -6,6 +6,8 @@ import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
+import com.project200.domain.usecase.ClearSessionUseCase
+import com.project200.domain.usecase.GetMemberIdUseCase
 import com.project200.domain.usecase.LoginUseCase
 import com.project200.undabang.oauth.AuthManager
 import com.project200.undabang.oauth.AuthStateManager
@@ -32,6 +34,8 @@ class MainViewModel
         private val networkMonitor: NetworkMonitor,
         private val authManager: AuthManager,
         private val authStateManager: AuthStateManager,
+        private val clearSessionUseCase: ClearSessionUseCase,
+        private val getMemberIdUseCase: GetMemberIdUseCase,
     ) : ViewModel() {
         private val _entryState = MutableStateFlow<EntryState>(EntryState.Loading)
         val entryState: StateFlow<EntryState> = _entryState.asStateFlow()
@@ -74,17 +78,23 @@ class MainViewModel
                     throw e
                 } catch (e: Exception) {
                     Timber.e(e, "진입 플로우 실패 - 로그인 화면으로 폴백")
-                    _entryState.value = EntryState.Login
+                    transitionToLogin()
                 }
             }
         }
 
         private suspend fun routeByAuth() {
             val state = authStateManager.getCurrent()
+            // 토큰 만료 시 refresh 시도, 실패 시 로그인 화면으로
             if (!state.isAuthorized) {
-                _entryState.value = EntryState.Login
+                transitionToLogin()
                 return
             }
+            if(getMemberIdUseCase().isNullOrBlank()) {
+                transitionToLogin()
+                return
+            }
+
             if (state.needsTokenRefresh) {
                 when (val result = authManager.refreshAccessToken()) {
                     is TokenRefreshResult.Success -> Unit
@@ -94,7 +104,7 @@ class MainViewModel
                             ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
                                 ex.error == "invalid_grant"
                         if (invalidGrant) {
-                            _entryState.value = EntryState.Login
+                            transitionToLogin()
                             return
                         }
                         Timber.w("Token refresh 일시 실패 - 오프라인 진입")
@@ -103,7 +113,7 @@ class MainViewModel
                     is TokenRefreshResult.NoRefreshToken,
                     is TokenRefreshResult.ConfigError,
                     -> {
-                        _entryState.value = EntryState.Login
+                        transitionToLogin()
                         return
                     }
                 }
@@ -117,7 +127,7 @@ class MainViewModel
             viewModelScope.launch {
                 authManager.forceLogoutFlow.collect {
                     Timber.w("강제 로그아웃 이벤트 - Login 전이")
-                    _entryState.value = EntryState.Login
+                    transitionToLogin()
                 }
             }
         }
@@ -171,6 +181,12 @@ class MainViewModel
                         Timber.w("서버 로그인 실패 - 재연결 시 재시도 예정")
                     }
                 }
+        }
+
+        private suspend fun transitionToLogin() {
+            runCatching { clearSessionUseCase() }
+                .onFailure { Timber.e(it, "세션 정리 실패 - 전이는 계속") }
+            _entryState.value = EntryState.Login
         }
 
         companion object {

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -7,6 +7,9 @@ import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
 import com.project200.domain.usecase.LoginUseCase
+import com.project200.undabang.oauth.AuthManager
+import com.project200.undabang.oauth.AuthStateManager
+import com.project200.undabang.oauth.TokenRefreshResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -16,8 +19,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import net.openid.appauth.AuthorizationException
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel
 class MainViewModel
@@ -26,6 +31,8 @@ class MainViewModel
         private val checkForUpdateUseCase: CheckForUpdateUseCase,
         private val loginUseCase: LoginUseCase,
         private val networkMonitor: NetworkMonitor,
+        private val authManager: AuthManager,
+        private val authStateManager: AuthStateManager,
     ) : ViewModel() {
         private val _updateCheckResult = MutableStateFlow<UpdateCheckResult?>(null)
         val updateCheckResult: StateFlow<UpdateCheckResult?> = _updateCheckResult.asStateFlow()
@@ -36,21 +43,79 @@ class MainViewModel
         private val _forceUpdateAfterReconnect = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
         val forceUpdateAfterReconnect: SharedFlow<Unit> = _forceUpdateAfterReconnect.asSharedFlow()
 
-        private var isContentShown = false
-        private var serverLoginPending = false
         private var wasOffline = !networkMonitor.isCurrentlyConnected()
+
+        private val _entryState = MutableStateFlow<EntryState>(EntryState.Loading)
+        val entryState: StateFlow<EntryState> = _entryState.asStateFlow()
+
+        // 선택(비강제) 업데이트 다이얼로그용
+        private val _optionalUpdate = MutableStateFlow(false)
+        val optionalUpdate: StateFlow<Boolean> = _optionalUpdate.asStateFlow()
+
+        private var serverLoginPending = false
 
         init {
             observeNetworkReconnection()
         }
 
+        /** onCreate에서 1회. 회전 재생성 시 StateFlow 값이 살아 있어 자동 멱등 */
+        fun startEntry() {
+            if (_entryState.value != EntryState.Loading) return
+            viewModelScope.launch {
+                val update = checkForUpdateUseCase().getOrElse {
+                    // 업데이트 확인 실패. 오프라인이라고 간주하고 진행
+                    UpdateCheckResult.NoUpdateNeeded
+                }
+                if (update is UpdateCheckResult.UpdateAvailable) {
+                    if (update.isForceUpdate) {
+                        _entryState.value = EntryState.ForceUpdate(fromReconnect = false)
+                        return@launch
+                    }
+                    _optionalUpdate.value = true // 선택 업데이트는 라우팅과 병행 (기존 동작 유지)
+                }
+                routeByAuth()
+            }
+        }
+        private suspend fun routeByAuth() {
+            val state = authStateManager.getCurrent()
+            if (!state.isAuthorized) {
+                _entryState.value = EntryState.Login
+                return
+            }
+            if (state.needsTokenRefresh) {
+                when (val r = authManager.refreshAccessToken()) {
+                    is TokenRefreshResult.Success -> Unit
+                    is TokenRefreshResult.Error -> {
+                        val ex = r.exception
+                        val invalidGrant = ex?.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR &&
+                                ex.error == "invalid_grant"
+                        if (invalidGrant) {
+                            _entryState.value = EntryState.Login
+                            return
+                        }
+                        Timber.w("Token refresh 일시 실패 - 오프라인 진입")
+                    }
+                    is TokenRefreshResult.NoRefreshToken,
+                    is TokenRefreshResult.ConfigError,
+                        -> {
+                        _entryState.value = EntryState.Login
+                        return
+                    }
+                }
+            }
+            ensureFcmRegistration()
+            _entryState.value = EntryState.Content
+        }
+
+        /** 선택 업데이트 다이얼로그 표시 완료 */
+        fun onOptionalUpdateShown() {
+            _optionalUpdate.value = false
+        }
+
         private fun observeNetworkReconnection() {
             viewModelScope.launch {
                 networkMonitor.networkState.collect { isOnline ->
-                    if (isOnline && wasOffline && isContentShown) {
-                        if (serverLoginPending) {
-                            loginInBackground()
-                        }
+                    if (isOnline && wasOffline && _entryState.value is EntryState.Content) {
                         recheckForUpdateOnReconnect()
                     }
                     wasOffline = !isOnline
@@ -59,21 +124,14 @@ class MainViewModel
         }
 
         private suspend fun recheckForUpdateOnReconnect() {
-            // onAvailable 직후 일시적 불안정 대비 딜레이
-            delay(RECONNECT_UPDATE_CHECK_DELAY_MS)
+            delay(RECONNECT_UPDATE_CHECK_DELAY_MS.milliseconds)
             checkForUpdateUseCase()
                 .onSuccess { result ->
                     if (result is UpdateCheckResult.UpdateAvailable && result.isForceUpdate) {
-                        _forceUpdateAfterReconnect.tryEmit(Unit)
+                        _entryState.value = EntryState.ForceUpdate(fromReconnect = true)
                     }
                 }
-                .onFailure { e ->
-                    Timber.w(e, "재연결 후 업데이트 확인 실패 - 무시")
-                }
-        }
-
-        fun onContentShown() {
-            isContentShown = true
+                .onFailure { Timber.w(it, "재연결 후 업데이트 확인 실패 - 무시") }
         }
 
         // 업데이트 확인
@@ -96,28 +154,13 @@ class MainViewModel
             }
         }
 
-        // POST /login — 진입 게이트와 무관하게 백그라운드에서 실행
-        // 실패 시 serverLoginPending = true, 재연결 시 자동 재시도
-        fun loginInBackground() {
+        private fun ensureFcmRegistration() {
             viewModelScope.launch {
                 val result = loginUseCase()
-                if (result is BaseResult.Success) {
-                    serverLoginPending = false
-                    Timber.d("서버 로그인 성공")
-                } else {
-                    serverLoginPending = true
-                    Timber.w("서버 로그인 실패 - 재연결 시 재시도 예정")
-                }
+                serverLoginPending = result !is BaseResult.Success  // 실패 시 재연결 때 재시도
             }
         }
 
-        fun showBottomNavigation() {
-            _showBottomNavigation.value = true
-        }
-
-        fun hideBottomNavigation() {
-            _showBottomNavigation.value = false
-        }
 
         companion object {
             private const val RECONNECT_UPDATE_CHECK_DELAY_MS = 1500L

--- a/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
+++ b/app/src/main/java/com/project200/undabang/main/MainViewModel.kt
@@ -62,10 +62,11 @@ class MainViewModel
         private fun startEntry() {
             viewModelScope.launch {
                 try {
-                    val update = checkForUpdateUseCase().getOrElse {
-                        Timber.e(it, "업데이트 확인 실패 - NoUpdateNeeded로 진행")
-                        UpdateCheckResult.NoUpdateNeeded
-                    }
+                    val update =
+                        checkForUpdateUseCase().getOrElse {
+                            Timber.e(it, "업데이트 확인 실패 - NoUpdateNeeded로 진행")
+                            UpdateCheckResult.NoUpdateNeeded
+                        }
                     if (update is UpdateCheckResult.UpdateAvailable) {
                         if (update.isForceUpdate) {
                             _entryState.compareAndSet(EntryState.Loading, EntryState.ForceUpdate(fromReconnect = false))
@@ -90,7 +91,7 @@ class MainViewModel
                 transitionToLogin()
                 return
             }
-            if(getMemberIdUseCase().isNullOrBlank()) {
+            if (getMemberIdUseCase().isNullOrBlank()) {
                 transitionToLogin()
                 return
             }

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -6,19 +6,26 @@ import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
 import com.project200.domain.usecase.LoginUseCase
+import com.project200.undabang.oauth.AuthManager
+import com.project200.undabang.oauth.AuthStateManager
+import com.project200.undabang.oauth.TokenRefreshResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import net.openid.appauth.AuthState
+import net.openid.appauth.AuthorizationException
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -38,8 +45,15 @@ class MainViewModelTest {
     @MockK
     private lateinit var mockNetworkMonitor: NetworkMonitor
 
+    @MockK
+    private lateinit var mockAuthManager: AuthManager
+
+    @MockK
+    private lateinit var mockAuthStateManager: AuthStateManager
+
     private lateinit var viewModel: MainViewModel
     private lateinit var networkStateFlow: MutableSharedFlow<Boolean>
+    private lateinit var forceLogoutFlow: MutableSharedFlow<Unit>
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -47,8 +61,10 @@ class MainViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         networkStateFlow = MutableSharedFlow()
+        forceLogoutFlow = MutableSharedFlow(extraBufferCapacity = 1)
         every { mockNetworkMonitor.networkState } returns networkStateFlow
         every { mockNetworkMonitor.isCurrentlyConnected() } returns true
+        every { mockAuthManager.forceLogoutFlow } returns forceLogoutFlow
     }
 
     @After
@@ -61,330 +77,410 @@ class MainViewModelTest {
             checkForUpdateUseCase = mockCheckForUpdateUseCase,
             loginUseCase = mockLoginUseCase,
             networkMonitor = mockNetworkMonitor,
+            authManager = mockAuthManager,
+            authStateManager = mockAuthStateManager,
         )
     }
 
-    @Test
-    fun `오프라인 콜드스타트 - 첫 온라인 전환에 업데이트를 재확인한다`() =
-        runTest {
-            // Given: 오프라인 상태로 시작
-            every { mockNetworkMonitor.isCurrentlyConnected() } returns false
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
-            viewModel = createViewModel()
-            testDispatcher.scheduler.runCurrent()
-            viewModel.onContentShown()
+    /** 토큰 상태 스텁. AuthState는 AppAuth 클래스라 mockk로 만든다 */
+    private fun stubAuthState(
+        isAuthorized: Boolean,
+        needsRefresh: Boolean = false,
+    ) {
+        val authState = mockk<AuthState>()
+        every { authState.isAuthorized } returns isAuthorized
+        every { authState.needsTokenRefresh } returns needsRefresh
+        every { mockAuthStateManager.getCurrent() } returns authState
+    }
 
-            // When: 망이 붙어 첫 emit이 true로 옴 (false emit 없음)
-            launch { networkStateFlow.emit(true) }
+    private fun stubNoUpdate() {
+        coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
+    }
+
+    // ── 진입 라우팅 ──────────────────────────────────────────────
+
+    @Test
+    fun `진입 - 토큰이 유효하면 Content로 전이하고 FCM 등록을 1회 수행한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = false)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+
+            // When: init이 진입을 시작한다 — 별도 호출 없음
+            viewModel = createViewModel()
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Then: 재확인이 일어난다
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
             coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
-        }
-
-    @Test
-    fun `온라인 콜드스타트 - 첫 onAvailable emit에 재확인이 헛발 실행되지 않는다`() =
-        runTest {
-            // Given: 온라인 상태로 시작 (setUp 기본값)
-            viewModel = createViewModel()
-            testDispatcher.scheduler.runCurrent()
-            viewModel.onContentShown()
-
-            // When: registerNetworkCallback 직후 시스템이 쏘는 onAvailable
-            launch { networkStateFlow.emit(true) }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then: 재확인 없음
-            coVerify(exactly = 0) { mockCheckForUpdateUseCase() }
-        }
-
-    @Test
-    fun `checkForUpdate - 업데이트가 필요하면 UpdateAvailable 결과를 반환한다`() =
-        runTest {
-            // Given
-            val updateResult = UpdateCheckResult.UpdateAvailable(isForceUpdate = false)
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(updateResult)
-
-            viewModel = createViewModel()
-
-            // When
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(viewModel.updateCheckResult.value).isEqualTo(updateResult)
-            coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
-        }
-
-    @Test
-    fun `checkForUpdate - 강제 업데이트가 필요하면 isForceUpdate가 true인 결과를 반환한다`() =
-        runTest {
-            // Given
-            val updateResult = UpdateCheckResult.UpdateAvailable(isForceUpdate = true)
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(updateResult)
-
-            viewModel = createViewModel()
-
-            // When
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            val result = viewModel.updateCheckResult.value
-            assertThat(result).isInstanceOf(UpdateCheckResult.UpdateAvailable::class.java)
-            assertThat((result as UpdateCheckResult.UpdateAvailable).isForceUpdate).isTrue()
-        }
-
-    @Test
-    fun `checkForUpdate - 업데이트가 불필요하면 NoUpdateNeeded 결과를 반환한다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
-
-            viewModel = createViewModel()
-
-            // When
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(viewModel.updateCheckResult.value).isEqualTo(UpdateCheckResult.NoUpdateNeeded)
-        }
-
-    @Test
-    fun `checkForUpdate - 이미 체크했으면 다시 호출하지 않는다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
-
-            viewModel = createViewModel()
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // When
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
-        }
-
-    @Test
-    fun `checkForUpdate - 실패해도 NoUpdateNeeded를 방출해 라우팅이 진행된다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
-
-            viewModel = createViewModel()
-
-            // When
-            viewModel.checkForUpdate()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(viewModel.updateCheckResult.value).isEqualTo(UpdateCheckResult.NoUpdateNeeded)
-        }
-
-    @Test
-    fun `재연결 - 콘텐츠 진입 후 오프라인에서 온라인으로 전환되면 강제 업데이트 이벤트를 방출한다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns
-                Result.success(
-                    UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
-                )
-            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            viewModel = createViewModel()
-            viewModel.onContentShown()
-
-            val events = mutableListOf<Unit>()
-            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
-            testDispatcher.scheduler.runCurrent()
-            testDispatcher.scheduler.advanceUntilIdle() // collectJob이 구독을 시작한 뒤 emit
-
-            // When: offline → online 전환 (emit은 collect lambda 완료를 대기하므로 별도 코루틴으로)
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(events).hasSize(1)
-            collectJob.cancel()
-        }
-
-    @Test
-    fun `재연결 - 선택 업데이트면 강제 업데이트 이벤트를 방출하지 않는다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns
-                Result.success(
-                    UpdateCheckResult.UpdateAvailable(isForceUpdate = false),
-                )
-            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            viewModel = createViewModel()
-            viewModel.onContentShown()
-
-            val events = mutableListOf<Unit>()
-            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
-            testDispatcher.scheduler.runCurrent()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // When: offline → online 전환
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(events).isEmpty()
-            collectJob.cancel()
-        }
-
-    @Test
-    fun `재연결 - 업데이트 확인 실패 시 강제 업데이트 이벤트를 방출하지 않는다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
-            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            viewModel = createViewModel()
-            viewModel.onContentShown()
-
-            val events = mutableListOf<Unit>()
-            val collectJob = launch { viewModel.forceUpdateAfterReconnect.collect { events.add(it) } }
-            testDispatcher.scheduler.runCurrent()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // When: offline → online 전환
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            assertThat(events).isEmpty()
-            collectJob.cancel()
-        }
-
-    @Test
-    fun `재연결 - 콘텐츠 진입 전에는 온라인 전환이 업데이트 재확인을 트리거하지 않는다`() =
-        runTest {
-            // Given
-            coEvery { mockCheckForUpdateUseCase() } returns
-                Result.success(
-                    UpdateCheckResult.UpdateAvailable(isForceUpdate = true),
-                )
-            viewModel = createViewModel()
-            testDispatcher.scheduler.runCurrent()
-            // onContentShown() 호출 안 함
-
-            // When: offline → online 전환
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then: UseCase 호출 없음
-            coVerify(exactly = 0) { mockCheckForUpdateUseCase() }
-        }
-
-    @Test
-    fun `loginInBackground - 서버 로그인을 백그라운드에서 호출한다`() =
-        runTest {
-            // Given
-            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            viewModel = createViewModel()
-
-            // When
-            viewModel.loginInBackground()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
             coVerify(exactly = 1) { mockLoginUseCase() }
         }
 
     @Test
-    fun `loginInBackground - 실패하면 재연결 시 재시도한다`() =
+    fun `진입 - 미인증이면 Login으로 전이하고 FCM 등록을 하지 않는다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = false)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+            coVerify(exactly = 0) { mockLoginUseCase() }
+        }
+
+    @Test
+    fun `진입 - 토큰 갱신 성공이면 Content로 전이한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = true)
+            coEvery { mockAuthManager.refreshAccessToken() } returns TokenRefreshResult.Success(mockk())
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+        }
+
+    @Test
+    fun `진입 - 갱신이 invalid_grant면 Login으로 전이한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = true)
+            coEvery { mockAuthManager.refreshAccessToken() } returns
+                    TokenRefreshResult.Error(AuthorizationException.TokenRequestErrors.INVALID_GRANT)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+            coVerify(exactly = 0) { mockLoginUseCase() }
+        }
+
+    @Test
+    fun `진입 - 갱신이 네트워크 오류면 오프라인으로 Content 진입한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = true)
+            coEvery { mockAuthManager.refreshAccessToken() } returns
+                    TokenRefreshResult.Error(AuthorizationException.GeneralErrors.NETWORK_ERROR)
+            coEvery { mockLoginUseCase() } returns BaseResult.Error("NETWORK_ERROR", "오프라인")
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+        }
+
+    @Test
+    fun `진입 - 리프레시 토큰이 없으면 Login으로 전이한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = true)
+            coEvery { mockAuthManager.refreshAccessToken() } returns TokenRefreshResult.NoRefreshToken
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+        }
+
+    @Test
+    fun `진입 - 예상 밖 예외가 나도 크래시 없이 Login으로 폴백한다`() =
+        runTest {
+            // Given: apiCallBuilder 밖 스택(AuthStateManager)에서 예외
+            stubNoUpdate()
+            every { mockAuthStateManager.getCurrent() } throws RuntimeException("keystore corrupted")
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 진입 코루틴은 반드시 상태 전이로 끝난다
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+        }
+
+    // ── 업데이트 게이트 ──────────────────────────────────────────
+
+    @Test
+    fun `진입 - 강제 업데이트면 ForceUpdate로 전이하고 라우팅을 진행하지 않는다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns
+                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 게이트 닫힘 — 토큰 판정·FCM 등록 미진행
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.ForceUpdate(fromReconnect = false))
+            coVerify(exactly = 0) { mockLoginUseCase() }
+        }
+
+    @Test
+    fun `진입 - 선택 업데이트면 다이얼로그 플래그를 켜고 라우팅은 병행한다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns
+                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = false))
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.optionalUpdate.value).isTrue()
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+
+            // 표시 완료 소비
+            viewModel.onOptionalUpdateShown()
+            assertThat(viewModel.optionalUpdate.value).isFalse()
+        }
+
+    @Test
+    fun `진입 - 업데이트 확인이 실패해도 라우팅이 진행된다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns Result.failure(Exception("Network error"))
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 스플래시에 갇히지 않는다
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+        }
+
+    // ── forceLogout ─────────────────────────────────────────────
+
+    @Test
+    fun `forceLogout - Content 중 수신하면 Login으로 전이한다`() =
+        runTest {
+            // Given: 정상 진입 완료
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+
+            // When: 사용 중 invalid_grant (TokenAuthenticator 경유)
+            forceLogoutFlow.emit(Unit)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+        }
+
+    @Test
+    fun `forceLogout - 진입 도중 수신해도 뒤늦은 Content가 Login을 덮지 않는다`() =
+        runTest {
+            // Given: refresh 도중 forceLogout이 발행되는 시나리오 (invalid_grant와 동일 타이밍)
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, needsRefresh = true)
+            coEvery { mockAuthManager.refreshAccessToken() } coAnswers {
+                forceLogoutFlow.emit(Unit) // 갱신 도중 강제 로그아웃 발생
+                TokenRefreshResult.Error(AuthorizationException.GeneralErrors.NETWORK_ERROR) // 진입은 오프라인 경로로 완주 시도
+            }
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 진입 코루틴이 완주해 Content를 쓰려 해도 compareAndSet(Loading, Content)이 실패한다
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+        }
+
+    // ── 재연결 ──────────────────────────────────────────────────
+
+    @Test
+    fun `재연결 - 오프라인 콜드스타트 후 첫 온라인 전환에 업데이트를 재확인한다`() =
+        runTest {
+            // Given: 오프라인 상태로 시작해 Content 진입 (진입 시 확인 1회)
+            every { mockNetworkMonitor.isCurrentlyConnected() } returns false
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // When: 망이 붙어 첫 emit이 true로 옴 (false emit 없음)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 진입 1회 + 재확인 1회
+            coVerify(exactly = 2) { mockCheckForUpdateUseCase() }
+        }
+
+    @Test
+    fun `재연결 - 온라인 시작이면 첫 onAvailable emit에 재확인이 헛발 실행되지 않는다`() =
+        runTest {
+            // Given: 온라인 시작(setUp 기본값)으로 Content 진입
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // When: registerNetworkCallback 직후 시스템이 쏘는 onAvailable
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 재확인 없음 (진입 1회뿐)
+            coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
+
+            // 그리고 정상 재연결(false → true)은 동작한다 — 경로가 죽어서 1회인 게 아님을 고정
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+            coVerify(exactly = 2) { mockCheckForUpdateUseCase() }
+        }
+
+    @Test
+    fun `재연결 - Content가 아니면 재확인을 트리거하지 않는다`() =
+        runTest {
+            // Given: 미인증으로 Login에 머무는 상태
+            stubNoUpdate()
+            stubAuthState(isAuthorized = false)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then: 진입 1회뿐
+            coVerify(exactly = 1) { mockCheckForUpdateUseCase() }
+        }
+
+    @Test
+    fun `재연결 - 재확인에서 강제 업데이트면 ForceUpdate로 전이한다`() =
+        runTest {
+            // Given: Content 진입 (진입 시엔 업데이트 없음, 재확인에선 강제 업데이트)
+            coEvery { mockCheckForUpdateUseCase() } returns
+                    Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
+                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // When: offline → online 전환
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.ForceUpdate(fromReconnect = true))
+        }
+
+    @Test
+    fun `재연결 - 재확인이 실패하면 무시하고 Content를 유지한다`() =
+        runTest {
+            // Given
+            coEvery { mockCheckForUpdateUseCase() } returns
+                    Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
+                    Result.failure(Exception("Network error"))
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // When
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Content)
+        }
+
+    // ── FCM 등록 ────────────────────────────────────────────────
+
+    @Test
+    fun `FCM 등록 - 실패하면 재연결 때 재시도한다`() =
         runTest {
             // Given: 처음엔 실패, 이후엔 성공
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns
-                BaseResult.Error("NETWORK_ERROR", "네트워크 오류") andThen
-                BaseResult.Success(Unit)
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
+                    BaseResult.Error("NETWORK_ERROR", "네트워크 오류") andThen
+                    BaseResult.Success(Unit)
             viewModel = createViewModel()
-            viewModel.onContentShown()
-
-            // When: 최초 로그인 실패
-            viewModel.loginInBackground()
             testDispatcher.scheduler.advanceUntilIdle()
 
             // When: offline → online 재연결
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Then: 총 2회 호출 (최초 + 재시도)
+            // Then: 진입 1회 + 재시도 1회
             coVerify(exactly = 2) { mockLoginUseCase() }
         }
 
     @Test
-    fun `loginInBackground - 성공하면 재연결 시 재시도하지 않는다`() =
+    fun `FCM 등록 - 성공하면 재연결 때 재시도하지 않는다`() =
         runTest {
             // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
-            coEvery { mockCheckForUpdateUseCase() } returns Result.success(UpdateCheckResult.NoUpdateNeeded)
             viewModel = createViewModel()
-            viewModel.onContentShown()
-
-            // When: 최초 로그인 성공
-            viewModel.loginInBackground()
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // When: offline → online 재연결
-            launch { networkStateFlow.emit(false) }
-            launch { networkStateFlow.emit(true) }
+            // When
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Then: 최초 1회만 호출
+            // Then: 진입 1회뿐
             coVerify(exactly = 1) { mockLoginUseCase() }
         }
 
     @Test
-    fun `showBottomNavigation - 호출하면 true가 설정된다`() =
+    fun `FCM 등록 - 요청이 진행 중이면 재연결이 겹쳐도 중복 발행하지 않는다`() =
         runTest {
-            // Given
+            // Given: 등록 요청이 느리게 진행 중
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true)
+            coEvery { mockLoginUseCase() } coAnswers {
+                delay(10_000) // 응답 지연 — 이 사이 재연결이 겹친다
+                BaseResult.Error("NETWORK_ERROR", "타임아웃")
+            }
             viewModel = createViewModel()
+            testDispatcher.scheduler.runCurrent() // 진입 시작 → 등록 요청 발사(지연 중)
 
-            // When
-            viewModel.showBottomNavigation()
+            // When: 요청이 나는 중에 offline → online 재연결
+            networkStateFlow.emit(false)
+            networkStateFlow.emit(true)
+            testDispatcher.scheduler.runCurrent()
 
-            // Then
-            assertThat(viewModel.showBottomNavigation.value).isTrue()
-        }
-
-    @Test
-    fun `hideBottomNavigation - 호출하면 false가 설정된다`() =
-        runTest {
-            // Given
-            viewModel = createViewModel()
-
-            // When
-            viewModel.hideBottomNavigation()
-
-            // Then
-            assertThat(viewModel.showBottomNavigation.value).isFalse()
-        }
-
-    @Test
-    fun `showBottomNavigation과 hideBottomNavigation - 토글이 정상 동작한다`() =
-        runTest {
-            // Given
-            viewModel = createViewModel()
-
-            // When & Then
-            viewModel.showBottomNavigation()
-            assertThat(viewModel.showBottomNavigation.value).isTrue()
-
-            viewModel.hideBottomNavigation()
-            assertThat(viewModel.showBottomNavigation.value).isFalse()
-
-            viewModel.showBottomNavigation()
-            assertThat(viewModel.showBottomNavigation.value).isTrue()
+            // Then: 실행 중 가드(registrationJob.isActive)가 두 번째 발사를 막는다
+            coVerify(exactly = 1) { mockLoginUseCase() }
         }
 }

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -5,15 +5,19 @@ import com.project200.common.utils.NetworkMonitor
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.UpdateCheckResult
 import com.project200.domain.usecase.CheckForUpdateUseCase
+import com.project200.domain.usecase.ClearSessionUseCase
+import com.project200.domain.usecase.GetMemberIdUseCase
 import com.project200.domain.usecase.LoginUseCase
 import com.project200.undabang.oauth.AuthManager
 import com.project200.undabang.oauth.AuthStateManager
 import com.project200.undabang.oauth.TokenRefreshResult
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,6 +54,12 @@ class MainViewModelTest {
     @MockK
     private lateinit var mockAuthStateManager: AuthStateManager
 
+    @MockK
+    private lateinit var mockClearSessionUseCase: ClearSessionUseCase
+
+    @MockK
+    private lateinit var mockGetMemberIdUseCase: GetMemberIdUseCase
+
     private lateinit var viewModel: MainViewModel
     private lateinit var networkStateFlow: MutableSharedFlow<Boolean>
     private lateinit var forceLogoutFlow: MutableSharedFlow<Unit>
@@ -64,6 +74,7 @@ class MainViewModelTest {
         every { mockNetworkMonitor.networkState } returns networkStateFlow
         every { mockNetworkMonitor.isCurrentlyConnected() } returns true
         every { mockAuthManager.forceLogoutFlow } returns forceLogoutFlow
+        coEvery { mockClearSessionUseCase() } just Runs
     }
 
     @After
@@ -78,18 +89,25 @@ class MainViewModelTest {
             networkMonitor = mockNetworkMonitor,
             authManager = mockAuthManager,
             authStateManager = mockAuthStateManager,
+            clearSessionUseCase = mockClearSessionUseCase,
+            getMemberIdUseCase = mockGetMemberIdUseCase,
         )
     }
 
-    /** 토큰 상태 스텁. AuthState는 AppAuth 클래스라 mockk로 만든다 */
+    /** 토큰 상태 스텁. AuthState는 AppAuth 클래스라 mockk로 만든다.
+     *  isAuthorized가 true면 회원ID 조회도 함께 스텁한다(기본값 "member-1", memberId로 override 가능). */
     private fun stubAuthState(
         isAuthorized: Boolean,
         needsRefresh: Boolean = false,
+        memberId: String? = "member-1",
     ) {
         val authState = mockk<AuthState>()
         every { authState.isAuthorized } returns isAuthorized
         every { authState.needsTokenRefresh } returns needsRefresh
         every { mockAuthStateManager.getCurrent() } returns authState
+        if (isAuthorized) {
+            coEvery { mockGetMemberIdUseCase() } returns memberId
+        }
     }
 
     private fun stubNoUpdate() {
@@ -199,6 +217,22 @@ class MainViewModelTest {
 
             // Then
             assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+        }
+
+    @Test
+    fun `진입 - 토큰은 유효하지만 회원ID가 없으면 Login으로 전이한다`() =
+        runTest {
+            // Given
+            stubNoUpdate()
+            stubAuthState(isAuthorized = true, memberId = null)
+
+            // When
+            viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.entryState.value).isEqualTo(EntryState.Login)
+            coVerify(exactly = 0) { mockLoginUseCase() }
         }
 
     @Test

--- a/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/project200/undabang/main/MainViewModelTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -157,7 +156,7 @@ class MainViewModelTest {
             stubNoUpdate()
             stubAuthState(isAuthorized = true, needsRefresh = true)
             coEvery { mockAuthManager.refreshAccessToken() } returns
-                    TokenRefreshResult.Error(AuthorizationException.TokenRequestErrors.INVALID_GRANT)
+                TokenRefreshResult.Error(AuthorizationException.TokenRequestErrors.INVALID_GRANT)
 
             // When
             viewModel = createViewModel()
@@ -175,7 +174,7 @@ class MainViewModelTest {
             stubNoUpdate()
             stubAuthState(isAuthorized = true, needsRefresh = true)
             coEvery { mockAuthManager.refreshAccessToken() } returns
-                    TokenRefreshResult.Error(AuthorizationException.GeneralErrors.NETWORK_ERROR)
+                TokenRefreshResult.Error(AuthorizationException.GeneralErrors.NETWORK_ERROR)
             coEvery { mockLoginUseCase() } returns BaseResult.Error("NETWORK_ERROR", "오프라인")
 
             // When
@@ -224,7 +223,7 @@ class MainViewModelTest {
         runTest {
             // Given
             coEvery { mockCheckForUpdateUseCase() } returns
-                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
+                Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
 
             // When
             viewModel = createViewModel()
@@ -240,7 +239,7 @@ class MainViewModelTest {
         runTest {
             // Given
             coEvery { mockCheckForUpdateUseCase() } returns
-                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = false))
+                Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = false))
             stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
 
@@ -383,8 +382,8 @@ class MainViewModelTest {
         runTest {
             // Given: Content 진입 (진입 시엔 업데이트 없음, 재확인에선 강제 업데이트)
             coEvery { mockCheckForUpdateUseCase() } returns
-                    Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
-                    Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
+                Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
+                Result.success(UpdateCheckResult.UpdateAvailable(isForceUpdate = true))
             stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
             viewModel = createViewModel()
@@ -404,8 +403,8 @@ class MainViewModelTest {
         runTest {
             // Given
             coEvery { mockCheckForUpdateUseCase() } returns
-                    Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
-                    Result.failure(Exception("Network error"))
+                Result.success(UpdateCheckResult.NoUpdateNeeded) andThen
+                Result.failure(Exception("Network error"))
             stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns BaseResult.Success(Unit)
             viewModel = createViewModel()
@@ -429,8 +428,8 @@ class MainViewModelTest {
             stubNoUpdate()
             stubAuthState(isAuthorized = true)
             coEvery { mockLoginUseCase() } returns
-                    BaseResult.Error("NETWORK_ERROR", "네트워크 오류") andThen
-                    BaseResult.Success(Unit)
+                BaseResult.Error("NETWORK_ERROR", "네트워크 오류") andThen
+                BaseResult.Success(Unit)
             viewModel = createViewModel()
             testDispatcher.scheduler.advanceUntilIdle()
 

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -27,26 +27,36 @@ class AuthRepositoryImpl
         private val authStateManager: AuthStateManager,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) : AuthRepository {
-        override suspend fun checkIsRegistered(): RegistrationStatus =
-            withContext(ioDispatcher) {
-                try {
-                    val response = apiService.getIsRegistered()
-                    if (response.data?.isRegistered == true) {
-                        spManager.saveMemberId(response.data.memberId)
-                        RegistrationStatus.Registered
-                    } else {
+        override suspend fun checkIsRegistered(): RegistrationStatus {
+            val result =
+                apiCallBuilder(
+                    ioDispatcher = ioDispatcher,
+                    apiCall = { apiService.getIsRegistered() },
+                    mapper = { data ->
+                        // 가입 확인된 경우에만 저장
+                        if (data != null && data.isRegistered) {
+                            spManager.saveMemberId(data.memberId)
+                            true
+                        } else {
+                            false
+                        }
+                    },
+                )
+
+            return when (result) {
+                is BaseResult.Success ->
+                    if (result.data) RegistrationStatus.Registered else RegistrationStatus.Unregistered
+                is BaseResult.Error ->
+                    // 미가입자는 인터셉터가 401 AUTHENTICATION_FAILED로 막는다
+                    if (result.errorCode == "AUTHENTICATION_FAILED") {
                         RegistrationStatus.Unregistered
+                    } else {
+                        // 게이트웨이 401("401") / USER_ID_HEADER_MISSING / NETWORK_ERROR / 500 → 판별 불가
+                        Timber.tag(TAG).w("checkIsRegistered failed: ${result.errorCode} ${result.message}")
+                        RegistrationStatus.Indeterminate
                     }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: IOException) {
-                    Timber.tag(TAG).w("checkIsRegistered network error: $e")
-                    RegistrationStatus.Indeterminate
-                } catch (e: Exception) {
-                    Timber.tag(TAG).w("checkIsRegistered failed: $e")
-                    RegistrationStatus.Indeterminate
-                }
             }
+        }
 
         override suspend fun login(): BaseResult<Unit> {
             return apiCallBuilder(

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -11,11 +11,9 @@ import com.project200.domain.model.BaseResult
 import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.repository.AuthRepository
 import com.project200.undabang.oauth.AuthStateManager
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.io.IOException
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -107,14 +105,14 @@ class AuthRepositoryImpl
             return spManager.getMemberId()
         }
 
-    override suspend fun clearSession() {
-        withContext(ioDispatcher) {
-            authStateManager.clearAuthState()
-            spManager.clearMemberId()
+        override suspend fun clearSession() {
+            withContext(ioDispatcher) {
+                authStateManager.clearAuthState()
+                spManager.clearMemberId()
+            }
         }
-    }
 
-    companion object {
+        companion object {
             const val TAG = "AuthRepositoryImpl"
         }
     }

--- a/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/AuthRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.project200.data.utils.apiCallBuilder
 import com.project200.domain.model.BaseResult
 import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.repository.AuthRepository
+import com.project200.undabang.oauth.AuthStateManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -23,14 +24,15 @@ class AuthRepositoryImpl
     constructor(
         private val apiService: ApiService,
         private val spManager: PreferenceManager,
+        private val authStateManager: AuthStateManager,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) : AuthRepository {
         override suspend fun checkIsRegistered(): RegistrationStatus =
             withContext(ioDispatcher) {
                 try {
                     val response = apiService.getIsRegistered()
-                    response.data?.let { spManager.saveMemberId(it.memberId) }
                     if (response.data?.isRegistered == true) {
+                        spManager.saveMemberId(response.data.memberId)
                         RegistrationStatus.Registered
                     } else {
                         RegistrationStatus.Unregistered
@@ -91,11 +93,18 @@ class AuthRepositoryImpl
             )
         }
 
-        override suspend fun getMemberId(): String {
-            return spManager.getMemberId().toString()
+        override suspend fun getMemberId(): String? {
+            return spManager.getMemberId()
         }
 
-        companion object {
+    override suspend fun clearSession() {
+        withContext(ioDispatcher) {
+            authStateManager.clearAuthState()
+            spManager.clearMemberId()
+        }
+    }
+
+    companion object {
             const val TAG = "AuthRepositoryImpl"
         }
     }

--- a/data/src/main/java/com/project200/data/impl/ChatSocketRepositoryImpl.kt
+++ b/data/src/main/java/com/project200/data/impl/ChatSocketRepositoryImpl.kt
@@ -61,7 +61,7 @@ class ChatSocketRepositoryImpl
         private val _opponentStatusChanges = MutableSharedFlow<OpponentStatus>()
         override val opponentStatusChanges = _opponentStatusChanges.asSharedFlow()
 
-        private val memberId = spManager.getMemberId().toString()
+        private val memberId: String? = spManager.getMemberId()
         private var currentChatRoomId: Long = -1L
         private var isUserInChatRoom = false
         private var retryCount = AtomicInteger(0)

--- a/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
+++ b/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
@@ -60,8 +60,8 @@ suspend fun <DTO, Domain> apiCallBuilder(
                             )
                         }
                         val errorBody = exception.response()?.errorBody()?.string()
-
                         var errorMessage = errorBody // 기본값은 파싱 전 원본 문자열
+                        var serverCode: String? = null
 
                         Timber.d("errorBody: $errorBody")
                         if (!errorBody.isNullOrBlank()) {
@@ -78,13 +78,14 @@ suspend fun <DTO, Domain> apiCallBuilder(
                                 if (errorResponse != null && !errorResponse.message.isNullOrEmpty()) {
                                     Timber.d("Parsed error message: ${errorResponse.message}")
                                     errorMessage = errorResponse.message
+                                    serverCode = errorResponse.code
                                 }
                             } catch (e: Exception) {
                                 Timber.e(e, "Failed to parse error body JSON with Moshi.")
                             }
                         }
                         BaseResult.Error(
-                            errorCode = exception.code().toString(),
+                            errorCode = serverCode ?: exception.code().toString(),
                             message = errorMessage, // 추출한 메시지 또는 원본 문자열 사용
                             cause = exception,
                         )

--- a/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
+++ b/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
@@ -75,9 +75,11 @@ suspend fun <DTO, Domain> apiCallBuilder(
                                 val errorResponse = adapter.fromJson(errorBody)
 
                                 // 파싱 성공 후 메시지가 있다면 사용
-                                if (errorResponse != null && !errorResponse.message.isNullOrEmpty()) {
-                                    Timber.d("Parsed error message: ${errorResponse.message}")
-                                    errorMessage = errorResponse.message
+                                if (errorResponse != null) {
+                                    if(!errorResponse.message.isNullOrEmpty()) {
+                                        Timber.d("Parsed error message: ${errorResponse.message}")
+                                        errorMessage = errorResponse.message
+                                    }
                                     serverCode = errorResponse.code
                                 }
                             } catch (e: Exception) {

--- a/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
+++ b/data/src/main/java/com/project200/data/utils/ApiCallBuilder.kt
@@ -76,7 +76,7 @@ suspend fun <DTO, Domain> apiCallBuilder(
 
                                 // 파싱 성공 후 메시지가 있다면 사용
                                 if (errorResponse != null) {
-                                    if(!errorResponse.message.isNullOrEmpty()) {
+                                    if (!errorResponse.message.isNullOrEmpty()) {
                                         Timber.d("Parsed error message: ${errorResponse.message}")
                                         errorMessage = errorResponse.message
                                     }

--- a/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/project200/domain/repository/AuthRepository.kt
@@ -10,5 +10,6 @@ interface AuthRepository {
     suspend fun logout(): BaseResult<Unit>
     suspend fun signUp(gender: String, nickname: String, birth: LocalDate): BaseResult<Unit>
     suspend fun checkNicknameDuplicated(nickname: String): BaseResult<Boolean>
-    suspend fun getMemberId(): String
+    suspend fun getMemberId(): String?
+    suspend fun clearSession()
 }

--- a/domain/src/main/java/com/project200/domain/usecase/ClearSessionUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/ClearSessionUseCase.kt
@@ -1,0 +1,10 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class ClearSessionUseCase
+@Inject
+constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke() = authRepository.clearSession()
+}

--- a/domain/src/main/java/com/project200/domain/usecase/GetMemberIdUseCase.kt
+++ b/domain/src/main/java/com/project200/domain/usecase/GetMemberIdUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class GetMemberIdUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(): String {
+    suspend operator fun invoke(): String? {
         return authRepository.getMemberId()
     }
 }

--- a/domain/src/test/java/com/project200/domain/usecase/ClearSessionUseCaseTest.kt
+++ b/domain/src/test/java/com/project200/domain/usecase/ClearSessionUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.project200.domain.usecase
+
+import com.project200.domain.repository.AuthRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit4.MockKRule
+import io.mockk.just
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ClearSessionUseCaseTest {
+
+    @get:Rule
+    val mockkRule = MockKRule(this)
+
+    @MockK
+    private lateinit var mockRepository: AuthRepository
+
+    private lateinit var useCase: ClearSessionUseCase
+
+    @Before
+    fun setUp() {
+        useCase = ClearSessionUseCase(mockRepository)
+    }
+
+    @Test
+    fun `invoke 호출 시 repository clearSession 호출`() = runTest {
+        // Given
+        coEvery { mockRepository.clearSession() } just Runs
+
+        // When
+        useCase()
+
+        // Then
+        coVerify(exactly = 1) { mockRepository.clearSession() }
+    }
+}

--- a/domain/src/test/java/com/project200/domain/usecase/GetMemberIdUseCaseTest.kt
+++ b/domain/src/test/java/com/project200/domain/usecase/GetMemberIdUseCaseTest.kt
@@ -55,4 +55,17 @@ class GetMemberIdUseCaseTest {
         coVerify(exactly = 1) { mockRepository.getMemberId() }
         assertThat(result).isEmpty()
     }
+
+    @Test
+    fun `invoke 호출 시 memberId가 없으면 null 반환`() = runTest {
+        // Given
+        coEvery { mockRepository.getMemberId() } returns null
+
+        // When
+        val result = useCase()
+
+        // Then
+        coVerify(exactly = 1) { mockRepository.getMemberId() }
+        assertThat(result).isNull()
+    }
 }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.project200.domain.model.BaseResult
+import com.project200.domain.model.RegistrationStatus
 import com.project200.presentation.base.BindingActivity
 import com.project200.presentation.navigator.ActivityNavigator
 import com.project200.undabang.auth.register.RegisterActivity
@@ -139,26 +140,13 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
     }
 
     override fun setupObservers() {
-        viewModel.loginResult.observe(this) { result ->
-            when (result) {
-                is BaseResult.Success -> appNavigator.navigateToMain(this)
-                is BaseResult.Error -> {
-                    if (result.errorCode == "NETWORK_ERROR") {
-                        Toast.makeText(this, PresentationR.string.network_error, Toast.LENGTH_SHORT).show()
-                    } else {
-                        startActivity(Intent(this@LoginActivity, RegisterActivity::class.java))
-                    }
-                }
-            }
-        }
-        viewModel.fcmTokenEvent.observe(this) { result ->
-            when (result) {
-                is BaseResult.Success -> {
-                    Timber.d(getString(R.string.fcm_token_send_success))
-                }
-                is BaseResult.Error -> {
-                    Timber.d(getString(R.string.fcm_token_not_found))
-                }
+        viewModel.registrationResult.observe(this) { status ->
+            when (status) {
+                RegistrationStatus.Registered -> appNavigator.navigateToMain(this)
+                RegistrationStatus.Unregistered ->
+                    startActivity(Intent(this@LoginActivity, RegisterActivity::class.java))
+                RegistrationStatus.Indeterminate ->
+                    Toast.makeText(this, PresentationR.string.network_error, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.project200.domain.model.BaseResult
 import com.project200.domain.model.RegistrationStatus
 import com.project200.presentation.base.BindingActivity
 import com.project200.presentation.navigator.ActivityNavigator

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginActivity.kt
@@ -64,7 +64,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>() {
 
             override fun onSuccess(tokenResponse: TokenResponse) {
                 Timber.tag(TAG).i(getString(R.string.login_success_with_token, tokenResponse.accessToken))
-                viewModel.sendFcmToken()
                 viewModel.checkIsRegistered()
             }
 

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginViewModel.kt
@@ -5,7 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.project200.domain.model.BaseResult
-import com.project200.domain.usecase.LoginUseCase
+import com.project200.domain.model.RegistrationStatus
+import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.domain.usecase.SendFcmTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -15,26 +16,14 @@ import javax.inject.Inject
 class LoginViewModel
     @Inject
     constructor(
-        private val loginUseCase: LoginUseCase,
-        private val sendFcmTokenUseCase: SendFcmTokenUseCase,
+        private val checkIsRegisteredUseCase: CheckIsRegisteredUseCase,
     ) : ViewModel() {
-        private val _loginResult = MutableLiveData<BaseResult<Unit>>()
-        val loginResult: LiveData<BaseResult<Unit>> = _loginResult
-
-        private val _fcmTokenEvent = MutableLiveData<BaseResult<Unit>>()
-        val fcmTokenEvent: LiveData<BaseResult<Unit>> = _fcmTokenEvent
+        private val _registrationResult = MutableLiveData<RegistrationStatus>()
+        val registrationResult: LiveData<RegistrationStatus> = _registrationResult
 
         fun checkIsRegistered() {
             viewModelScope.launch {
-                _loginResult.value = loginUseCase()
-            }
-        }
-
-        // fcm 토큰 전송
-        fun sendFcmToken() {
-            viewModelScope.launch {
-                val result = sendFcmTokenUseCase()
-                _fcmTokenEvent.value = result
+                _registrationResult.value = checkIsRegisteredUseCase()
             }
         }
     }

--- a/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/login/LoginViewModel.kt
@@ -4,10 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.project200.domain.model.BaseResult
 import com.project200.domain.model.RegistrationStatus
 import com.project200.domain.usecase.CheckIsRegisteredUseCase
-import com.project200.domain.usecase.SendFcmTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
+++ b/feature/auth/src/main/java/com/project200/undabang/auth/register/RegisterFragment.kt
@@ -99,7 +99,7 @@ class RegisterFragment : Fragment() {
     }
 
     companion object {
-        const val NICKNAME_DUPLICATE_ERROR = "409"
+        const val NICKNAME_DUPLICATE_ERROR = "MEMBER_NICKNAME_DUPLICATED"
         const val MALE = "M"
         const val FEMALE = "F"
         const val HIDDEN = "U"

--- a/feature/auth/src/test/java/com/project200/undabang/auth/LoginViewModelTest.kt
+++ b/feature/auth/src/test/java/com/project200/undabang/auth/LoginViewModelTest.kt
@@ -65,7 +65,7 @@ class LoginViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertThat(viewModel.loginResult.value).isInstanceOf(BaseResult.Success::class.java)
+            assertThat(viewModel.registrationResult.value).isInstanceOf(BaseResult.Success::class.java)
             coVerify(exactly = 1) { loginUseCase() }
         }
 
@@ -81,7 +81,7 @@ class LoginViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            val result = viewModel.loginResult.value
+            val result = viewModel.registrationResult.value
             assertThat(result).isInstanceOf(BaseResult.Error::class.java)
             assertThat((result as BaseResult.Error).errorCode).isEqualTo("ERROR")
         }

--- a/feature/auth/src/test/java/com/project200/undabang/auth/LoginViewModelTest.kt
+++ b/feature/auth/src/test/java/com/project200/undabang/auth/LoginViewModelTest.kt
@@ -2,9 +2,8 @@ package com.project200.undabang.auth
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
-import com.project200.domain.model.BaseResult
-import com.project200.domain.usecase.LoginUseCase
-import com.project200.domain.usecase.SendFcmTokenUseCase
+import com.project200.domain.model.RegistrationStatus
+import com.project200.domain.usecase.CheckIsRegisteredUseCase
 import com.project200.undabang.auth.login.LoginViewModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -30,10 +29,7 @@ class LoginViewModelTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @MockK
-    private lateinit var loginUseCase: LoginUseCase
-
-    @MockK
-    private lateinit var sendFcmTokenUseCase: SendFcmTokenUseCase
+    private lateinit var checkIsRegisteredUseCase: CheckIsRegisteredUseCase
 
     private lateinit var viewModel: LoginViewModel
 
@@ -50,14 +46,14 @@ class LoginViewModelTest {
     }
 
     private fun createViewModel(): LoginViewModel {
-        return LoginViewModel(loginUseCase, sendFcmTokenUseCase)
+        return LoginViewModel(checkIsRegisteredUseCase)
     }
 
     @Test
-    fun `checkIsRegistered - 로그인 성공 시 Success 결과를 반환한다`() =
+    fun `checkIsRegistered - 가입된 사용자면 Registered 결과를 반환한다`() =
         runTest {
             // Given
-            coEvery { loginUseCase() } returns BaseResult.Success(Unit)
+            coEvery { checkIsRegisteredUseCase() } returns RegistrationStatus.Registered
             viewModel = createViewModel()
 
             // When
@@ -65,15 +61,15 @@ class LoginViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertThat(viewModel.registrationResult.value).isInstanceOf(BaseResult.Success::class.java)
-            coVerify(exactly = 1) { loginUseCase() }
+            assertThat(viewModel.registrationResult.value).isEqualTo(RegistrationStatus.Registered)
+            coVerify(exactly = 1) { checkIsRegisteredUseCase() }
         }
 
     @Test
-    fun `checkIsRegistered - 로그인 실패 시 Error 결과를 반환한다`() =
+    fun `checkIsRegistered - 미가입 사용자면 Unregistered 결과를 반환한다`() =
         runTest {
             // Given
-            coEvery { loginUseCase() } returns BaseResult.Error("ERROR", "Login failed")
+            coEvery { checkIsRegisteredUseCase() } returns RegistrationStatus.Unregistered
             viewModel = createViewModel()
 
             // When
@@ -81,43 +77,23 @@ class LoginViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            val result = viewModel.registrationResult.value
-            assertThat(result).isInstanceOf(BaseResult.Error::class.java)
-            assertThat((result as BaseResult.Error).errorCode).isEqualTo("ERROR")
+            assertThat(viewModel.registrationResult.value).isEqualTo(RegistrationStatus.Unregistered)
+            coVerify(exactly = 1) { checkIsRegisteredUseCase() }
         }
 
     @Test
-    fun `sendFcmToken - FCM 토큰 전송 성공 시 Success 이벤트를 발생시킨다`() =
+    fun `checkIsRegistered - 확인 불가면 Indeterminate 결과를 반환한다`() =
         runTest {
             // Given
-            coEvery { loginUseCase() } returns BaseResult.Success(Unit)
-            coEvery { sendFcmTokenUseCase() } returns BaseResult.Success(Unit)
+            coEvery { checkIsRegisteredUseCase() } returns RegistrationStatus.Indeterminate
             viewModel = createViewModel()
 
             // When
-            viewModel.sendFcmToken()
+            viewModel.checkIsRegistered()
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then
-            assertThat(viewModel.fcmTokenEvent.value).isInstanceOf(BaseResult.Success::class.java)
-            coVerify(exactly = 1) { sendFcmTokenUseCase() }
-        }
-
-    @Test
-    fun `sendFcmToken - FCM 토큰 전송 실패 시 Error 이벤트를 발생시킨다`() =
-        runTest {
-            // Given
-            coEvery { loginUseCase() } returns BaseResult.Success(Unit)
-            coEvery { sendFcmTokenUseCase() } returns BaseResult.Error("FCM_ERROR", "FCM token send failed")
-            viewModel = createViewModel()
-
-            // When
-            viewModel.sendFcmToken()
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            // Then
-            val result = viewModel.fcmTokenEvent.value
-            assertThat(result).isInstanceOf(BaseResult.Error::class.java)
-            assertThat((result as BaseResult.Error).errorCode).isEqualTo("FCM_ERROR")
+            assertThat(viewModel.registrationResult.value).isEqualTo(RegistrationStatus.Indeterminate)
+            coVerify(exactly = 1) { checkIsRegisteredUseCase() }
         }
 }

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
@@ -103,10 +103,12 @@ class SettingFragment : Fragment() {
             } catch (e: Exception) {
                 Timber.e(e, "로그아웃 실패")
             }
+            var logoutPageLaunched = false
             authManager.logout(
                 authService,
                 object : LogoutResultCallback {
                     override fun onLogoutPageIntentReady(logoutIntent: Intent) {
+                        logoutPageLaunched = true
                         logoutPageLauncher.launch(logoutIntent)
                     }
 
@@ -121,6 +123,9 @@ class SettingFragment : Fragment() {
                     }
                 },
             )
+
+            runCatching { viewModel.clearLocalSession() }
+            if (!logoutPageLaunched) appNavigator.navigateToLogin(requireContext())
         }
     }
 

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
@@ -103,7 +103,6 @@ class SettingFragment : Fragment() {
             } catch (e: Exception) {
                 Timber.e(e, "로그아웃 실패")
             }
-
             authManager.logout(
                 authService,
                 object : LogoutResultCallback {

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingFragment.kt
@@ -119,7 +119,6 @@ class SettingFragment : Fragment() {
                     override fun onLogoutProcessError(exception: Exception) {
                         Timber.e(exception, "로그아웃 에러: ${exception.message}")
                         Toast.makeText(requireContext(), getString(R.string.logout_error), Toast.LENGTH_LONG).show()
-                        appNavigator.navigateToLogin(requireContext())
                     }
                 },
             )

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
@@ -13,8 +13,6 @@ class SettingViewModel
         private val logoutUseCase: LogoutUseCase,
         private val clearSessionUseCase: ClearSessionUseCase,
     ) : ViewModel() {
-        suspend fun logout() {
-            logoutUseCase()
-            clearSessionUseCase()
-        }
+        suspend fun logout() = logoutUseCase()
+        suspend fun clearLocalSession() = clearSessionUseCase()
     }

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
@@ -1,6 +1,7 @@
 package com.project200.undabang.profile.setting
 
 import androidx.lifecycle.ViewModel
+import com.project200.domain.usecase.ClearSessionUseCase
 import com.project200.domain.usecase.LogoutUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -10,8 +11,10 @@ class SettingViewModel
     @Inject
     constructor(
         private val logoutUseCase: LogoutUseCase,
+        private val clearSessionUseCase: ClearSessionUseCase,
     ) : ViewModel() {
         suspend fun logout() {
             logoutUseCase()
+            clearSessionUseCase()
         }
     }

--- a/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
+++ b/feature/profile/src/main/java/com/project200/undabang/profile/setting/SettingViewModel.kt
@@ -14,5 +14,6 @@ class SettingViewModel
         private val clearSessionUseCase: ClearSessionUseCase,
     ) : ViewModel() {
         suspend fun logout() = logoutUseCase()
+
         suspend fun clearLocalSession() = clearSessionUseCase()
     }

--- a/feature/profile/src/test/java/com/project200/undabang/profile/setting/SettingViewModelTest.kt
+++ b/feature/profile/src/test/java/com/project200/undabang/profile/setting/SettingViewModelTest.kt
@@ -1,11 +1,14 @@
 package com.project200.undabang.profile.setting
 
 import com.project200.domain.model.BaseResult
+import com.project200.domain.usecase.ClearSessionUseCase
 import com.project200.domain.usecase.LogoutUseCase
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import io.mockk.just
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -25,6 +28,9 @@ class SettingViewModelTest {
     @MockK
     private lateinit var mockLogoutUseCase: LogoutUseCase
 
+    @MockK
+    private lateinit var mockClearSessionUseCase: ClearSessionUseCase
+
     private lateinit var viewModel: SettingViewModel
 
     private val testDispatcher = StandardTestDispatcher()
@@ -43,6 +49,7 @@ class SettingViewModelTest {
         viewModel =
             SettingViewModel(
                 logoutUseCase = mockLogoutUseCase,
+                clearSessionUseCase = mockClearSessionUseCase,
             )
     }
 
@@ -57,5 +64,18 @@ class SettingViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             coVerify(exactly = 1) { mockLogoutUseCase() }
+        }
+
+    @Test
+    fun `clearLocalSession - clearSessionUseCase가 호출된다`() =
+        runTest {
+            coEvery { mockClearSessionUseCase() } just Runs
+
+            createViewModel()
+
+            viewModel.clearLocalSession()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 1) { mockClearSessionUseCase() }
         }
 }


### PR DESCRIPTION
## 개요

entry-state 리팩터링(#562): 앱 진입 라우팅을 `EntryState` 기반으로 재구성하고, 세션 정리(`ClearSessionUseCase`)·회원ID 확인 흐름을 정비했습니다. 프로덕션 변경에 맞춰 유닛 테스트를 정합화했습니다.

## 변경 내용

### 프로덕션 (기존 브랜치 커밋)
- `EntryState` sealed class 도입, `MainViewModel` 진입 라우팅 재구성 (업데이트 확인 → 토큰 → 회원ID 순 분기, 실패 시 Login 폴백 + 세션 정리)
- `AuthRepository.getMemberId()` nullable화, `clearSession()` 추가, `ClearSessionUseCase` 신규
- `LoginViewModel`을 `CheckIsRegisteredUseCase` + `RegistrationStatus` 기반으로 교체 (FCM 전송 로직 제거)
- `SettingViewModel`에 `clearSessionUseCase` 주입, 로그인 화면 이동 시 토큰·ID 삭제

### 테스트 정합화 (마지막 커밋)
- `MainViewModelTest`: 새 생성자 인자(`clearSessionUseCase`·`getMemberIdUseCase`) 반영, 회원ID 없음 → Login 전이 테스트 추가
- `LoginViewModelTest`: 삭제된 `LoginUseCase`/`SendFcmTokenUseCase` 참조 제거, `RegistrationStatus` 3분기 검증으로 재작성
- `SettingViewModelTest`: `clearSessionUseCase` 인자 반영 + `clearLocalSession()` 테스트 추가
- `GetMemberIdUseCaseTest`: null 반환 케이스 추가
- `ClearSessionUseCaseTest` 신규

## 확인 필요

- [ ] 로컬 SDK 부재로 테스트 미실행 — 이 PR의 CI(`android-dev-ci.yml`: lint, ktlintCheck, testDebugUnitTest) 통과 확인 필요
